### PR TITLE
feat: Support large size

### DIFF
--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -13,6 +13,7 @@ import { PrismAsyncLight as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { ghcolors } from 'react-syntax-highlighter/dist/cjs/styles/prism';
 import { useStyles } from 'sku/react-treat';
 
+import { SIZE_TO_CODE_SIZE, Size } from '../private/size';
 import { codeCommentColor, monospaceFontFamily } from '../styles';
 
 import * as styleRefs from './CodeBlock.treat';
@@ -119,20 +120,26 @@ const GraphQLPlaygroundButton = ({
   );
 };
 
-const Pre = ({ children: [numbers, lines] }: { children: ReactNodeArray }) => {
+const createPre = (size: Size) => ({
+  children: [numbers, lines],
+}: {
+  children: ReactNodeArray;
+}) => {
   const styles = useStyles(styleRefs);
+
+  const codeSize = SIZE_TO_CODE_SIZE[size];
 
   return (
     <Box className={styles.preTag} component="pre">
       <Columns space="none">
         <Column width="content">
           <Box background="neutralLight" padding="medium">
-            <Text size="small">{numbers}</Text>
+            <Text size={codeSize}>{numbers}</Text>
           </Box>
         </Column>
         <Column>
           <Box padding="medium">
-            <Text size="small">{lines}</Text>
+            <Text size={codeSize}>{lines}</Text>
           </Box>
         </Column>
       </Columns>
@@ -144,10 +151,12 @@ export const CodeBlock = ({
   children,
   language = 'text',
   graphqlPlayground,
+  size = 'standard',
 }: {
   children: string;
   language: string;
   graphqlPlayground?: string;
+  size?: Size;
 }) => {
   const styles = useStyles(styleRefs);
 
@@ -164,7 +173,7 @@ export const CodeBlock = ({
     <Box className={styles.codeBlock} position="relative">
       <SyntaxHighlighter
         CodeTag={Code}
-        PreTag={Pre}
+        PreTag={createPre(size)}
         language={CODE_LANGUAGE_REPLACEMENTS[language] ?? language}
         lineNumberContainerProps={{
           style: {

--- a/src/components/MdxProvider.tsx
+++ b/src/components/MdxProvider.tsx
@@ -2,6 +2,7 @@ import { MDXProvider } from '@mdx-js/react';
 import React from 'react';
 
 import { GraphQLPlaygroundProvider } from '../private/hooks/graphqlPlayground';
+import { Size } from '../private/size';
 import { useMdxComponents } from '../private/useMdxComponents';
 
 interface MdxProviderProps {
@@ -11,13 +12,19 @@ interface MdxProviderProps {
    * This will enable a "Try in Playground" button for GraphQL code blocks
    */
   graphqlPlayground?: string;
+
+  /**
+   * Optional scaling factor for text and spacing
+   */
+  size?: Size;
 }
 
 export const MdxProvider: React.FunctionComponent<MdxProviderProps> = ({
   children,
   graphqlPlayground,
+  size = 'standard',
 }) => {
-  const components = useMdxComponents();
+  const components = useMdxComponents({ size });
 
   return (
     <GraphQLPlaygroundProvider value={graphqlPlayground}>

--- a/src/components/WrapperRenderer.tsx
+++ b/src/components/WrapperRenderer.tsx
@@ -10,7 +10,9 @@ export const WrapperRenderer = ({
   children: WrapperComponent;
   document: MDX.Document;
 }) => {
-  const wrapper = useMdxWrapper(children);
+  // The built-in wrapper size doesn't really matter here as the provided
+  // component can overwrite it.
+  const wrapper = useMdxWrapper(children, 'standard');
 
   return (
     <Document

--- a/src/private/CodeBlockWithPlayground.tsx
+++ b/src/private/CodeBlockWithPlayground.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { CodeBlock } from '../components/CodeBlock';
 
 import { useGraphQLPlayground } from './hooks/graphqlPlayground';
+import { Size } from './size';
 
 /**
  * Wraps `<CodeBlock>` with our GraphQL Playground URL
@@ -10,14 +11,20 @@ import { useGraphQLPlayground } from './hooks/graphqlPlayground';
 export const CodeBlockWithPlayground = ({
   children,
   language,
+  size,
 }: {
   children: string;
   language: string;
+  size: Size;
 }) => {
   const graphqlPlayground = useGraphQLPlayground();
 
   return (
-    <CodeBlock language={language} graphqlPlayground={graphqlPlayground}>
+    <CodeBlock
+      language={language}
+      graphqlPlayground={graphqlPlayground}
+      size={size}
+    >
       {children}
     </CodeBlock>
   );

--- a/src/private/Wrapper.tsx
+++ b/src/private/Wrapper.tsx
@@ -2,6 +2,7 @@ import { Box, Stack } from 'braid-design-system';
 import React from 'react';
 import { useStyles } from 'sku/react-treat';
 
+import { SIZE_TO_SPACE, Size } from './size';
 import { StackChildrenProps } from './types';
 
 import * as styleRefs from './Wrapper.treat';
@@ -10,14 +11,21 @@ export type WrapperComponent = React.FunctionComponent<StackChildrenProps>;
 
 type WrapperProps = StackChildrenProps & {
   component?: WrapperComponent;
+  size: Size;
 };
 
-export const Wrapper = ({ children, component: Component }: WrapperProps) => {
+export const Wrapper = ({
+  children,
+  component: Component,
+  size,
+}: WrapperProps) => {
   const styles = useStyles(styleRefs);
+
+  const space = SIZE_TO_SPACE[size];
 
   return (
     <Box className={styles.wrapper}>
-      <Stack space="medium">
+      <Stack space={space}>
         {typeof Component === 'undefined' ? (
           children
         ) : (

--- a/src/private/size.ts
+++ b/src/private/size.ts
@@ -1,0 +1,24 @@
+type CodeSize = 'small' | 'standard';
+
+type Padding = 'small' | 'medium';
+
+type Space = 'medium' | 'large';
+
+export type Size = typeof SIZES[number];
+
+export const SIZES = ['standard', 'large'] as const;
+
+export const SIZE_TO_CODE_SIZE: Record<Size, CodeSize> = {
+  standard: 'small',
+  large: 'standard',
+};
+
+export const SIZE_TO_PADDING: Record<Size, Padding> = {
+  standard: 'small',
+  large: 'medium',
+};
+
+export const SIZE_TO_SPACE: Record<Size, Space> = {
+  standard: 'medium',
+  large: 'large',
+};

--- a/src/private/useMdxComponents.treat.ts
+++ b/src/private/useMdxComponents.treat.ts
@@ -1,10 +1,12 @@
-import { style } from 'sku/treat';
+import { Style, style, styleMap } from 'sku/treat';
 
 import {
   alternateRowBackgroundColour,
   codeBackgroundColor,
   monospaceFontFamily,
 } from '../styles';
+
+import { SIZES, SIZE_TO_PADDING, SIZE_TO_SPACE, Size } from './size';
 
 export const image = style({
   maxWidth: '100%',
@@ -17,12 +19,18 @@ export const inlineCode = style({
   fontSize: '0.9em',
 });
 
-export const listGrid = style((theme) => ({
-  display: 'grid',
-  gridColumnGap: theme.grid * theme.space.small,
-  gridRowGap: theme.grid * theme.space.medium,
-  gridTemplateColumns: 'min-content minmax(0, 1fr)',
-}));
+export const listGrid = styleMap<Size>((theme) =>
+  SIZES.reduce<Record<Size, Style>>((acc, size) => {
+    acc[size] = {
+      display: 'grid',
+      gridColumnGap: theme.grid * theme.space[SIZE_TO_PADDING[size]],
+      gridRowGap: theme.grid * theme.space[SIZE_TO_SPACE[size]],
+      gridTemplateColumns: 'min-content minmax(0, 1fr)',
+    };
+
+    return acc;
+  }, {} as Record<Size, Style>),
+);
 
 export const orderedList = style({
   counterReset: 'ol',

--- a/src/private/useMdxComponents.tsx
+++ b/src/private/useMdxComponents.tsx
@@ -15,11 +15,19 @@ import { Blockquote } from './Blockquote';
 import { CodeBlockWithPlayground } from './CodeBlockWithPlayground';
 import { createSpacedHeading } from './SpacedHeading';
 import { Wrapper } from './Wrapper';
+import { SIZE_TO_PADDING, SIZE_TO_SPACE, Size } from './size';
 
 import * as styleRefs from './useMdxComponents.treat';
 
-export const useMdxComponents = (): MDX.ProviderComponents => {
+interface Props {
+  size: Size;
+}
+
+export const useMdxComponents = ({ size }: Props): MDX.ProviderComponents => {
   const styles = useStyles(styleRefs);
+
+  const padding = SIZE_TO_PADDING[size];
+  const space = SIZE_TO_SPACE[size];
 
   return {
     a: ({ children, href }) =>
@@ -41,7 +49,7 @@ export const useMdxComponents = (): MDX.ProviderComponents => {
       const language = className.replace(/^language-/, '');
 
       return (
-        <CodeBlockWithPlayground language={language}>
+        <CodeBlockWithPlayground language={language} size={size}>
           {String(children)}
         </CodeBlockWithPlayground>
       );
@@ -60,16 +68,19 @@ export const useMdxComponents = (): MDX.ProviderComponents => {
     img: (props) => <img {...props} className={styles.image} />,
     li: ({ children }) => (
       <Fragment>
-        <Text>
+        <Text size={size}>
           <Box className={styles.listItem} />
         </Text>
         <Box component="li">
-          <Stack space="medium">{children}</Stack>
+          <Stack space={space}>{children}</Stack>
         </Box>
       </Fragment>
     ),
     ol: ({ children }) => (
-      <Box className={[styles.listGrid, styles.orderedList]} component="ol">
+      <Box
+        className={[styles.listGrid[size], styles.orderedList]}
+        component="ol"
+      >
         {children}
       </Box>
     ),
@@ -77,7 +88,7 @@ export const useMdxComponents = (): MDX.ProviderComponents => {
     // renders inline formatting correctly and fixes the line height. If some
     // node is not wrapped in a paragraph and it should be, wrap it using a
     // remark plugin, not here.
-    p: Text,
+    p: ({ children }) => <Text size={size}>{children}</Text>,
     pre: ({ children }) => <pre className={styles.pre}>{children}</pre>,
     strong: Strong,
     table: ({ children }) => <table className={styles.table}>{children}</table>,
@@ -85,28 +96,31 @@ export const useMdxComponents = (): MDX.ProviderComponents => {
       <Box
         className={styles.tableCell}
         component="td"
-        padding="small"
+        padding={padding}
         textAlign={align === null ? 'left' : align}
       >
-        <Stack space="medium">{children}</Stack>
+        <Stack space={space}>{children}</Stack>
       </Box>
     ),
     th: ({ align, children }) => (
       <Box
         className={styles.tableCell}
         component="th"
-        padding="small"
+        padding={padding}
         textAlign={align === null ? 'center' : align}
       >
-        <Stack space="medium">{children}</Stack>
+        <Stack space={space}>{children}</Stack>
       </Box>
     ),
     tr: ({ children }) => <tr className={styles.tableRow}>{children}</tr>,
     ul: ({ children }) => (
-      <Box className={[styles.listGrid, styles.unorderedList]} component="ul">
+      <Box
+        className={[styles.listGrid[size], styles.unorderedList]}
+        component="ul"
+      >
         {children}
       </Box>
     ),
-    wrapper: Wrapper,
+    wrapper: ({ children }) => <Wrapper size={size}>{children}</Wrapper>,
   };
 };

--- a/src/private/useMdxWrapper.tsx
+++ b/src/private/useMdxWrapper.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
 
 import { Wrapper, WrapperComponent } from './Wrapper';
+import { Size } from './size';
 import { StackChildrenProps } from './types';
 
-export const useMdxWrapper = (component: WrapperComponent) => ({
+export const useMdxWrapper = (component: WrapperComponent, size: Size) => ({
   children,
-}: StackChildrenProps) => <Wrapper component={component}>{children}</Wrapper>;
+}: StackChildrenProps) => (
+  <Wrapper component={component} size={size}>
+    {children}
+  </Wrapper>
+);


### PR DESCRIPTION
This essentially adds a library-wide scaling factor via the `size` prop. The default remains at `standard`, while we introduce a new `large` size that is more suitable for fluffy things like <https://partner.seek.com>.