### PR TITLE
fix(MdxProvider): Keep heading anchors inline

### DIFF
--- a/.loki/reference/chrome_laptop_Headings_heading.png
+++ b/.loki/reference/chrome_laptop_Headings_heading.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e9ec38b15fcbd02e88f2d45b1ab37c8ddf508036964dad70b5125cda9a6929a4
-size 346300
+oid sha256:4c9d355d2e6b3048002dd31ee3d6982bb95b6ea7a1c48aac29bf7203494158c8
+size 352841

--- a/.loki/reference/chrome_laptop_ToC_toc.png
+++ b/.loki/reference/chrome_laptop_ToC_toc.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1babacd725aa861dc72a347da7e9a393d046fe0506f721f2cd2990737fea4955
-size 363900
+oid sha256:e5af3cfe84b0af55cbd8d0634d2168d5e2322aae3f1f9a8575052bf12888772b
+size 25858

--- a/src/private/SpacedHeading.tsx
+++ b/src/private/SpacedHeading.tsx
@@ -1,5 +1,5 @@
-import { Box, Heading, Inline, Text } from 'braid-design-system';
-import React from 'react';
+import { Box, Heading, Text } from 'braid-design-system';
+import React, { ReactNode } from 'react';
 import { HashLink } from 'react-router-hash-link';
 import { useStyles } from 'sku/react-treat';
 
@@ -7,11 +7,9 @@ import { HeadingLevel } from './types';
 
 import * as styleRefs from './SpacedHeading.treat';
 
-type InlineChildren = React.ComponentProps<typeof Inline>['children'];
-
 const headingForLevel: Record<
   HeadingLevel,
-  React.FunctionComponent<{ children: InlineChildren }>
+  React.FunctionComponent<{ children: ReactNode }>
 > = {
   1: ({ children }) => <Heading level="2">{children}</Heading>,
   2: ({ children }) => <Heading level="3">{children}</Heading>,
@@ -19,37 +17,36 @@ const headingForLevel: Record<
   4: ({ children }) => <Text weight="strong">{children}</Text>,
   5: ({ children }) => (
     <Text weight="strong">
-      <Inline space="xsmall">
-        <span>| </span>
-        {children}
-      </Inline>
+      <span>| </span>
+      {children}
     </Text>
   ),
   6: ({ children }) => (
     <Text weight="strong">
-      <Inline space="xsmall">
-        <span>‖ </span>
-        {children}
-      </Inline>
+      <span>‖ </span>
+      {children}
     </Text>
   ),
 };
 
+interface Props {
+  children: ReactNode;
+  id: string;
+}
+
 export const createSpacedHeading = (level: HeadingLevel) => {
   const LevelHeading = headingForLevel[level];
 
-  return ({ children, id }: { children: InlineChildren; id: string }) => {
+  return ({ children, id }: Props) => {
     const styles = useStyles(styleRefs);
 
     return (
       <Box className={styles.headingSpacer} id={id} tabIndex={0}>
         <LevelHeading>
-          <Inline space="xsmall">
-            {children}
-            <HashLink className={styles.headingAnchor} smooth to={`#${id}`}>
-              ⚓︎
-            </HashLink>
-          </Inline>
+          {children}{' '}
+          <HashLink className={styles.headingAnchor} smooth to={`#${id}`}>
+            ⚓︎
+          </HashLink>
         </LevelHeading>
       </Box>
     );

--- a/src/stories/markdowns.stories.tsx
+++ b/src/stories/markdowns.stories.tsx
@@ -57,8 +57,6 @@ storiesOf('ToC', module)
           </Text>
         )}
       </TocRenderer>
-
-      <Headings />
     </Stack>
   ))
   .addDecorator(withBraid);

--- a/src/stories/markdowns/headings.mdx
+++ b/src/stories/markdowns/headings.mdx
@@ -45,3 +45,5 @@ Cappuccino, coffee espresso so sit cinnamon cultivar affogato pumpkin spice. Vie
 Frappuccino cultivar, frappuccino, cultivar roast cappuccino wings frappuccino. Instant, froth brewed cup spoon instant americano. Mazagran so, barista so eu robust that.
 
 Iced doppio galão single shot dark café au lait bar robusta affogato. Shop java id, saucer black caffeine beans iced mazagran decaffeinated irish. At cream, saucer, siphon roast, and, sweet spoon caramelization aroma whipped.
+
+## Really really really really really really really really really really really really really really really really really really really really really really really really really long heading


### PR DESCRIPTION
When we had a heading that wrapped across multiple lines, its anchor decided to migrate to its own line. This fixes the issue by treating the anchor as ordinary inner text rather than using Braid's `<Inline>`.

---

Here's an example of the issue:

![Screen Shot 2020-06-12 at 13 13 49](https://user-images.githubusercontent.com/25572311/84461488-e9346200-acaf-11ea-9bd8-75fc16e38ade.png)
