### PR TITLE
fix(InternalTextLink): Fix for scrollable elements

### DIFF
--- a/src/private/InternalTextLink.tsx
+++ b/src/private/InternalTextLink.tsx
@@ -1,6 +1,6 @@
 import url from 'url';
 
-import { TextLinkRenderer, useSpace } from 'braid-design-system';
+import { TextLinkRenderer } from 'braid-design-system';
 import React, { ReactNode } from 'react';
 import { useLocation } from 'react-router-dom';
 import { HashLink } from 'react-router-hash-link';
@@ -57,21 +57,12 @@ export const parseInternalHref = (
   };
 };
 
-const scrollWithYOffset = (yOffset: number) => (element: Element) =>
-  setTimeout(() => {
-    const yCoordinate =
-      element.getBoundingClientRect().top + window.pageYOffset;
-
-    window.scrollTo({
-      behavior: 'smooth',
-      top: yCoordinate + yOffset,
-    });
-  });
-
 export const InternalTextLink = ({ children, href }: Props) => {
-  const { grid, space } = useSpace();
-
-  const scroll = scrollWithYOffset(-(grid * space.small));
+  const scroll = (element: Element) =>
+    // Scroll to the header's `Stack` element so we don't cut off the heading
+    (element.parentElement ?? element).scrollIntoView({
+      behavior: 'smooth',
+    });
 
   const location = useLocation();
 

--- a/src/private/InternalTextLink.tsx
+++ b/src/private/InternalTextLink.tsx
@@ -59,9 +59,11 @@ export const parseInternalHref = (
 
 export const InternalTextLink = ({ children, href }: Props) => {
   const scroll = (element: Element) =>
-    // Scroll to the header's `Stack` element so we don't cut off the heading
-    (element.parentElement ?? element).scrollIntoView({
-      behavior: 'smooth',
+    setTimeout(() => {
+      // Scroll to the header's `Stack` element so we don't cut off the heading
+      (element.parentElement ?? element).scrollIntoView({
+        behavior: 'smooth',
+      });
     });
 
   const location = useLocation();


### PR DESCRIPTION
The existing code made an assumption the entire page was being scrolled when calculating the scroll destination. However, in DEMI the content is in a separate scrollable `<div>` while the `<body>` remains scrolled to the top. When our smooth scrolling code ran it ended up trying to scroll the body down which ended up being a no-op.

I think the intent of the original override was to prevent the header text from being cut in half. We can kind of hack this by instead scrolling our *parent* in to view, which happens to be a stack div.