### PR TITLE
feat(MdxProvider): Uplift styling for APAC

### DIFF
--- a/.loki/reference/chrome_laptop_MdxProvider_Code.png
+++ b/.loki/reference/chrome_laptop_MdxProvider_Code.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3b37e80ff2d9ee9db375f38bae19e3857dbedb5e9246191dc88068046799f951
-size 183542
+oid sha256:4e9ee1160bc7e243ed462aa04ca8c7a80c9cfdeaebf2f1c4111cd24ed476fb21
+size 189928

--- a/.loki/reference/chrome_laptop_MdxProvider_Combination.png
+++ b/.loki/reference/chrome_laptop_MdxProvider_Combination.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2aaf60bbdeda4ab4fd03acb59dbe1a4bd204f3b010d34dc28d38c2d07f8352f1
-size 31676
+oid sha256:16fca18ccfa77d482dfbcb08ae074c82965e454637aa26d915d9a1783841d255
+size 32182

--- a/.loki/reference/chrome_laptop_MdxProvider_ImagesInternal.png
+++ b/.loki/reference/chrome_laptop_MdxProvider_ImagesInternal.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d958135745dbf5a57bbfacf5fdfe459c37b95d38b0523d8cd8ad65e802dde537
-size 187106
+oid sha256:d65078c164d4dfba85175761c35ec9f667e2e2f1b25557478fcd1e9d192460a1
+size 187809

--- a/.loki/reference/chrome_laptop_MdxProvider_Table.png
+++ b/.loki/reference/chrome_laptop_MdxProvider_Table.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:573bf3c50701f485da584bd1925d10548a441c58596d214722a8a7cfd7fa55c0
-size 23538
+oid sha256:286c566e6be7360298fb712f242d2c354b93c1a52eff9c7a2bdd4ab20ba0aee2
+size 24096

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@types/react-router-hash-link": "^1.2.1",
     "@types/react-syntax-highlighter": "^11.0.4",
     "find-up": "^4.1.0",
+    "polished": "^3.6.5",
     "react-router-hash-link": "^1.2.2",
     "react-syntax-highlighter": "^12.2.1",
     "remark-slug": "^6.0.0",

--- a/src/components/CodeBlock.treat.ts
+++ b/src/components/CodeBlock.treat.ts
@@ -1,20 +1,39 @@
+import { darken } from 'polished';
 import { style } from 'sku/treat';
 
-import { codeBackgroundColor, monospaceFontFamily } from '../styles';
+import { monospaceFontFamily } from '../styles';
 
 export const codeBlock = style({});
+
+export const lineNumberBox = style((theme) => ({
+  backgroundColor: darken(0.05, theme.color.background.body),
+  borderTopLeftRadius: theme.border.radius.standard,
+  borderBottomLeftRadius: theme.border.radius.standard,
+}));
+
+export const lineNumberContainer = style((theme) => ({
+  color: theme.color.foreground.secondary,
+  fontFamily: monospaceFontFamily,
+  fontSize: 'inherit',
+  lineHeight: 'inherit',
+  userSelect: 'none',
+}));
 
 export const codeTag = style({
   fontFamily: monospaceFontFamily,
 });
 
-export const buttonOuter = style((theme) =>
-  theme.utils.responsiveStyle({
+export const buttonOuter = style((theme) => ({
+  borderColor: darken(0.05, theme.color.background.body),
+  borderStyle: 'solid',
+  borderWidth: 1,
+  ':hover': {
+    cursor: 'pointer',
+  },
+
+  ...theme.utils.responsiveStyle({
     desktop: {
       opacity: 0,
-      ':hover': {
-        cursor: 'pointer',
-      },
       selectors: {
         [`${codeBlock}:hover &`]: {
           opacity: 1,
@@ -25,7 +44,7 @@ export const buttonOuter = style((theme) =>
       opacity: 1,
     },
   }),
-);
+}));
 
 export const buttonInner = style((theme) =>
   theme.utils.responsiveStyle({
@@ -44,7 +63,10 @@ export const buttonInner = style((theme) =>
 );
 
 export const preTag = style((theme) => ({
-  backgroundColor: codeBackgroundColor,
+  backgroundColor: theme.color.background.body,
+  borderColor: darken(0.05, theme.color.background.body),
+  borderStyle: 'solid',
+  borderWidth: 1,
   // this is super arbitrary at the moment
   maxHeight: theme.grid * theme.typography.text.small.tablet.size * 10,
   overflow: 'auto',

--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -14,7 +14,6 @@ import { ghcolors } from 'react-syntax-highlighter/dist/cjs/styles/prism';
 import { useStyles } from 'sku/react-treat';
 
 import { SIZE_TO_CODE_SIZE, Size } from '../private/size';
-import { codeCommentColor, monospaceFontFamily } from '../styles';
 
 import * as styleRefs from './CodeBlock.treat';
 
@@ -130,11 +129,13 @@ const createPre = (size: Size) => ({
   const codeSize = SIZE_TO_CODE_SIZE[size];
 
   return (
-    <Box className={styles.preTag} component="pre">
+    <Box borderRadius="standard" className={styles.preTag} component="pre">
       <Columns space="none">
         <Column width="content">
-          <Box background="neutralLight" padding="medium">
-            <Text size={codeSize}>{numbers}</Text>
+          <Box className={styles.lineNumberBox} padding="medium">
+            <Text align="right" size={codeSize}>
+              {numbers}
+            </Text>
           </Box>
         </Column>
         <Column>
@@ -176,12 +177,15 @@ export const CodeBlock = ({
         PreTag={createPre(size)}
         language={CODE_LANGUAGE_REPLACEMENTS[language] ?? language}
         lineNumberContainerProps={{
+          className: styles.lineNumberContainer,
+          // react-syntax-highlighter specifies some nonsense defaults, but they
+          // can be overwritten via object merge.
           style: {
-            color: codeCommentColor,
-            fontFamily: monospaceFontFamily,
-            fontSize: 'inherit',
-            lineHeight: 'inherit',
-            userSelect: 'none',
+            color: undefined,
+            fontFamily: undefined,
+            fontSize: undefined,
+            lineHeight: undefined,
+            userSelect: undefined,
           },
         }}
         showLineNumbers

--- a/src/private/useMdxComponents.treat.ts
+++ b/src/private/useMdxComponents.treat.ts
@@ -1,10 +1,7 @@
+import { darken } from 'polished';
 import { Style, style, styleMap } from 'sku/treat';
 
-import {
-  alternateRowBackgroundColour,
-  codeBackgroundColor,
-  monospaceFontFamily,
-} from '../styles';
+import { monospaceFontFamily } from '../styles';
 
 import { SIZES, SIZE_TO_PADDING, SIZE_TO_SPACE, Size } from './size';
 
@@ -12,12 +9,15 @@ export const image = style({
   maxWidth: '100%',
 });
 
-export const inlineCode = style({
-  backgroundColor: codeBackgroundColor,
+export const inlineCode = style((theme) => ({
+  backgroundColor: theme.color.background.body,
+  borderColor: darken(0.05, theme.color.background.body),
+  borderStyle: 'solid',
+  borderWidth: 1,
 
   fontFamily: monospaceFontFamily,
   fontSize: '0.9em',
-});
+}));
 
 export const listGrid = styleMap<Size>((theme) =>
   SIZES.reduce<Record<Size, Style>>((acc, size) => {
@@ -61,20 +61,51 @@ export const pre = style({
 });
 
 export const table = style({
-  borderCollapse: 'collapse',
+  borderCollapse: 'separate',
+  borderSpacing: 0,
 });
 
-export const tableRow = style({
+export const tableRow = style((theme) => ({
   selectors: {
     '&:nth-child(even)': {
-      backgroundColor: alternateRowBackgroundColour,
+      backgroundColor: theme.color.background.body,
     },
   },
-});
+}));
 
 export const tableCell = style((theme) => ({
-  borderColor: theme.color.background.neutral,
+  borderBottomWidth: 1,
+  borderColor: theme.border.color.standard,
+  borderRightWidth: 1,
   borderStyle: 'solid',
-  borderWidth: 1,
   verticalAlign: 'top',
+
+  ':first-child': {
+    borderLeftWidth: 1,
+  },
+}));
+
+export const td = style((theme) => ({
+  selectors: {
+    'tr:last-child &:first-child': {
+      borderBottomLeftRadius: theme.border.radius.standard,
+    },
+    'tr:last-child &:last-child': {
+      borderBottomRightRadius: theme.border.radius.standard,
+    },
+  },
+}));
+
+export const th = style((theme) => ({
+  selectors: {
+    'tr:first-child &': {
+      borderTopWidth: 1,
+    },
+    'tr:first-child &:first-child': {
+      borderTopLeftRadius: theme.border.radius.standard,
+    },
+    'tr:first-child &:last-child': {
+      borderTopRightRadius: theme.border.radius.standard,
+    },
+  },
 }));

--- a/src/private/useMdxComponents.tsx
+++ b/src/private/useMdxComponents.tsx
@@ -35,7 +35,12 @@ export const useMdxComponents = ({ size }: Props): MDX.ProviderComponents => {
       );
     },
     inlineCode: ({ children }) => (
-      <Box className={styles.inlineCode} component="code" padding="xxsmall">
+      <Box
+        borderRadius="standard"
+        className={styles.inlineCode}
+        component="code"
+        paddingX="xxsmall"
+      >
         {children}
       </Box>
     ),
@@ -71,10 +76,14 @@ export const useMdxComponents = ({ size }: Props): MDX.ProviderComponents => {
     p: ({ children }) => <Text size={size}>{children}</Text>,
     pre: ({ children }) => <pre className={styles.pre}>{children}</pre>,
     strong: Strong,
-    table: ({ children }) => <table className={styles.table}>{children}</table>,
+    table: ({ children }) => (
+      <Box component="table" className={styles.table}>
+        {children}
+      </Box>
+    ),
     td: ({ align, children }) => (
       <Box
-        className={styles.tableCell}
+        className={[styles.tableCell, styles.td]}
         component="td"
         padding={padding}
         textAlign={align === null ? 'left' : align}
@@ -84,7 +93,7 @@ export const useMdxComponents = ({ size }: Props): MDX.ProviderComponents => {
     ),
     th: ({ align, children }) => (
       <Box
-        className={styles.tableCell}
+        className={[styles.tableCell, styles.th]}
         component="th"
         padding={padding}
         textAlign={align === null ? 'center' : align}

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -1,12 +1,3 @@
-// Inspired by GitHub
-export const codeBackgroundColor = 'rgba(27, 31, 35, .05)';
-
-// Also inspired from GitHub
-export const alternateRowBackgroundColour = 'rgb(246, 248, 250)';
-
-// Taken from react-syntax-highlighter/dist/cjs/styles/prism/ghcolors
-export const codeCommentColor = 'rgb(153, 153, 136)';
-
 // SEEK's corporate font + GitHub defaults
 export const monospaceFontFamily =
   "'Roboto Mono',SFMono-Regular,Consolas,Liberation Mono,Menlo,monospace";

--- a/yarn.lock
+++ b/yarn.lock
@@ -12970,12 +12970,12 @@ pnp-webpack-plugin@1.5.0:
   dependencies:
     ts-pnp "^1.1.2"
 
-polished@^3.0.3, polished@^3.3.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/polished/-/polished-3.5.1.tgz#657b6faf4c2308f3e0b1951196803a5e5d67b122"
-  integrity sha512-GVbvskpBiDV5TknurGL6OyFfLHsCknxbU8w5iMppT8rW0tLEoQHrIRfrPNPqGXNj3HGhkjRvhmg59Fy7HSnCAw==
+polished@^3.0.3, polished@^3.3.1, polished@^3.6.5:
+  version "3.6.5"
+  resolved "https://registry.yarnpkg.com/polished/-/polished-3.6.5.tgz#dbefdde64c675935ec55119fe2a2ab627ca82e9c"
+  integrity sha512-VwhC9MlhW7O5dg/z7k32dabcAFW1VI2+7fSe8cE/kXcfL7mVdoa5UxciYGW2sJU78ldDLT6+ROEKIZKFNTnUXQ==
   dependencies:
-    "@babel/runtime" "^7.8.7"
+    "@babel/runtime" "^7.9.2"
 
 popper.js@^1.14.4, popper.js@^1.14.7:
   version "1.16.1"


### PR DESCRIPTION
This bundles a number of styling tweaks that bring us in line with the APAC Braid theme, which is now Scoobie's primary target.

- Round the borders of inline code, code blocks and tables.
- Use lighter borders for tables.
- Use body colour as the basis for code and table row backgrounds. This allows us to gain the bluish tint on the APAC theme without hardcoding colours like we did previously.
- Right-align line numbers in code blocks.
- Reduce inline code background height to prevent lines from hitting each other.