### PR TITLE
fix(MdxProvider): Wrap spans in scroll container

### DIFF
--- a/src/private/useMdxComponents.tsx
+++ b/src/private/useMdxComponents.tsx
@@ -50,7 +50,7 @@ export const useMdxComponents = ({ size }: Props): MDX.ProviderComponents => {
     h4: createSpacedHeading(4),
     h5: createSpacedHeading(5),
     h6: createSpacedHeading(6),
-    img: (props) => <img {...props} className={styles.image} />,
+    img: (props) => <Box {...props} className={styles.image} component="img" />,
     li: ({ children }) => (
       <Fragment>
         <Text size={size}>
@@ -74,7 +74,17 @@ export const useMdxComponents = ({ size }: Props): MDX.ProviderComponents => {
     // node is not wrapped in a paragraph and it should be, wrap it using a
     // remark plugin, not here.
     p: ({ children }) => <Text size={size}>{children}</Text>,
-    pre: ({ children }) => <pre className={styles.pre}>{children}</pre>,
+    pre: ({ children }) => (
+      <Box className={styles.pre} component="pre">
+        {children}
+      </Box>
+    ),
+    span: (props) => (
+      // For wide SVGs like Mermaid diagrams
+      <Box overflow="auto">
+        <Box {...props} component="span" />
+      </Box>
+    ),
     strong: Strong,
     table: ({ children }) => (
       <Box className={styles.tableWrapper}>
@@ -103,7 +113,11 @@ export const useMdxComponents = ({ size }: Props): MDX.ProviderComponents => {
         <Stack space={space}>{children}</Stack>
       </Box>
     ),
-    tr: ({ children }) => <tr className={styles.tableRow}>{children}</tr>,
+    tr: ({ children }) => (
+      <Box className={styles.tableRow} component="tr">
+        {children}
+      </Box>
+    ),
     ul: ({ children }) => (
       <Box
         className={[styles.listGrid[size], styles.unorderedList]}

--- a/types.d.ts
+++ b/types.d.ts
@@ -42,6 +42,7 @@ declare namespace MDX {
     ol: ProviderComponent;
     p: ProviderComponent;
     pre: ProviderComponent;
+    span: ProviderComponent;
     strong: ProviderComponent;
     table: ProviderComponent;
     tbody: ProviderComponent;


### PR DESCRIPTION
We've been incubating a Remark Mermaid plugin internally that renders diagrams out as `<span>`s. On mobile it probably makes sense for these diagrams to retain their original dimensions with the option to scroll, rather than shrinking them down to microscopic sizes.

This also wraps a few remaining elements in Braid `<Box>`es.