### PR TITLE
fix(CodeBlock): Hide line numbers from readers

### DIFF
--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -131,7 +131,7 @@ const createPre = (size: Size) => ({
   return (
     <Box borderRadius="standard" className={styles.preTag} component="pre">
       <Columns space="none">
-        <Column width="content">
+        <Column aria-hidden width="content">
           <Box className={styles.lineNumberBox} padding="medium">
             <Text align="right" size={codeSize}>
               {numbers}


### PR DESCRIPTION
These are not useful in a less visual format. For example, Firefox's reader view just dumps a list of numbers in a section before the code.