### PR TITLE
chore: Split out list components

### DIFF
--- a/src/private/List.treat.ts
+++ b/src/private/List.treat.ts
@@ -1,0 +1,43 @@
+import { Style, style, styleMap } from 'sku/treat';
+
+import { SIZES, SIZE_TO_PADDING, SIZE_TO_SPACE, Size } from './size';
+
+export const listGrid = styleMap<Size>((theme) =>
+  SIZES.reduce<Record<Size, Style>>((acc, size) => {
+    acc[size] = {
+      display: 'grid',
+      gridColumnGap: theme.grid * theme.space[SIZE_TO_PADDING[size]],
+      gridRowGap: theme.grid * theme.space[SIZE_TO_SPACE[size]],
+      gridTemplateColumns: 'min-content minmax(0, 1fr)',
+    };
+
+    return acc;
+  }, {} as Record<Size, Style>),
+);
+
+export const orderedList = style({
+  counterReset: 'ol',
+});
+
+export const unorderedList = style({
+  counterReset: 'ol',
+});
+
+export const listItem = style({
+  display: 'list-item',
+  textAlign: 'right',
+  selectors: {
+    [`${orderedList} > span > &, ${orderedList} > div > div > span > &:before`]: {
+      counterIncrement: 'ol',
+    },
+    [`${orderedList} > span > &:before, ${orderedList} > div > div > span > &:before`]: {
+      content: "counter(ol) '.'",
+    },
+    [`${unorderedList} > span > &:before, ${unorderedList} > div > div > span > &:before`]: {
+      content: "'•'",
+    },
+    [`${unorderedList} > span > &, ${unorderedList} > div > div > span > &`]: {
+      transform: 'scale(1.25)',
+    },
+  },
+});

--- a/src/private/List.tsx
+++ b/src/private/List.tsx
@@ -1,0 +1,51 @@
+import { Box, Stack, Text } from 'braid-design-system';
+import React, { ComponentProps, Fragment } from 'react';
+import { useStyles } from 'sku/react-treat';
+
+import { SIZE_TO_SPACE, Size } from './size';
+
+import * as styleRefs from './useMdxComponents.treat';
+
+type Props = Pick<ComponentProps<typeof Stack>, 'children'> & {
+  size: Size;
+};
+
+export const ListItem = ({ children, size }: Props) => {
+  const styles = useStyles(styleRefs);
+
+  const space = SIZE_TO_SPACE[size];
+
+  return (
+    <Fragment>
+      <Text size={size}>
+        <Box className={styles.listItem} />
+      </Text>
+      <Box component="li">
+        <Stack space={space}>{children}</Stack>
+      </Box>
+    </Fragment>
+  );
+};
+
+export const OrderedList = ({ children, size }: Props) => {
+  const styles = useStyles(styleRefs);
+
+  return (
+    <Box className={[styles.listGrid[size], styles.orderedList]} component="ol">
+      {children}
+    </Box>
+  );
+};
+
+export const UnorderedList = ({ children, size }: Props) => {
+  const styles = useStyles(styleRefs);
+
+  return (
+    <Box
+      className={[styles.listGrid[size], styles.unorderedList]}
+      component="ul"
+    >
+      {children}
+    </Box>
+  );
+};

--- a/src/private/List.tsx
+++ b/src/private/List.tsx
@@ -4,7 +4,7 @@ import { useStyles } from 'sku/react-treat';
 
 import { SIZE_TO_SPACE, Size } from './size';
 
-import * as styleRefs from './useMdxComponents.treat';
+import * as styleRefs from './List.treat';
 
 type Props = Pick<ComponentProps<typeof Stack>, 'children'> & {
   size: Size;

--- a/src/private/useMdxComponents.treat.ts
+++ b/src/private/useMdxComponents.treat.ts
@@ -1,9 +1,7 @@
 import { darken } from 'polished';
-import { Style, style, styleMap } from 'sku/treat';
+import { style } from 'sku/treat';
 
 import { monospaceFontFamily } from '../styles';
-
-import { SIZES, SIZE_TO_PADDING, SIZE_TO_SPACE, Size } from './size';
 
 export const inlineCode = style((theme) => ({
   backgroundColor: theme.color.background.body,
@@ -14,46 +12,6 @@ export const inlineCode = style((theme) => ({
   fontFamily: monospaceFontFamily,
   fontSize: '0.9em',
 }));
-
-export const listGrid = styleMap<Size>((theme) =>
-  SIZES.reduce<Record<Size, Style>>((acc, size) => {
-    acc[size] = {
-      display: 'grid',
-      gridColumnGap: theme.grid * theme.space[SIZE_TO_PADDING[size]],
-      gridRowGap: theme.grid * theme.space[SIZE_TO_SPACE[size]],
-      gridTemplateColumns: 'min-content minmax(0, 1fr)',
-    };
-
-    return acc;
-  }, {} as Record<Size, Style>),
-);
-
-export const orderedList = style({
-  counterReset: 'ol',
-});
-
-export const unorderedList = style({
-  counterReset: 'ol',
-});
-
-export const listItem = style({
-  display: 'list-item',
-  textAlign: 'right',
-  selectors: {
-    [`${orderedList} > span > &, ${orderedList} > div > div > span > &:before`]: {
-      counterIncrement: 'ol',
-    },
-    [`${orderedList} > span > &:before, ${orderedList} > div > div > span > &:before`]: {
-      content: "counter(ol) '.'",
-    },
-    [`${unorderedList} > span > &:before, ${unorderedList} > div > div > span > &:before`]: {
-      content: "'•'",
-    },
-    [`${unorderedList} > span > &, ${unorderedList} > div > div > span > &`]: {
-      transform: 'scale(1.25)',
-    },
-  },
-});
 
 export const pre = style({
   margin: 0,

--- a/src/private/useMdxComponents.tsx
+++ b/src/private/useMdxComponents.tsx
@@ -1,5 +1,5 @@
 import { Box, Stack, Strong, Text } from 'braid-design-system';
-import React, { Fragment } from 'react';
+import React from 'react';
 import { useStyles } from 'sku/react-treat';
 
 import { SmartTextLink } from '../components/SmartTextLink';
@@ -7,6 +7,7 @@ import { useImageStyles } from '../hooks/useImageStyles';
 
 import { Blockquote } from './Blockquote';
 import { CodeBlockWithPlayground } from './CodeBlockWithPlayground';
+import { ListItem, OrderedList, UnorderedList } from './List';
 import { createSpacedHeading } from './SpacedHeading';
 import { Wrapper } from './Wrapper';
 import { SIZE_TO_PADDING, SIZE_TO_SPACE, Size } from './size';
@@ -55,24 +56,8 @@ export const useMdxComponents = ({ size }: Props): MDX.ProviderComponents => {
     img: (props) => (
       <Box {...props} className={imageStyles.img} component="img" />
     ),
-    li: ({ children }) => (
-      <Fragment>
-        <Text size={size}>
-          <Box className={styles.listItem} />
-        </Text>
-        <Box component="li">
-          <Stack space={space}>{children}</Stack>
-        </Box>
-      </Fragment>
-    ),
-    ol: ({ children }) => (
-      <Box
-        className={[styles.listGrid[size], styles.orderedList]}
-        component="ol"
-      >
-        {children}
-      </Box>
-    ),
+    li: ({ children }) => <ListItem size={size}>{children}</ListItem>,
+    ol: ({ children }) => <OrderedList size={size}>{children}</OrderedList>,
     // Don't try to be clever here, this is what you want. No, really. `Text`
     // renders inline formatting correctly and fixes the line height. If some
     // node is not wrapped in a paragraph and it should be, wrap it using a
@@ -122,14 +107,7 @@ export const useMdxComponents = ({ size }: Props): MDX.ProviderComponents => {
         {children}
       </Box>
     ),
-    ul: ({ children }) => (
-      <Box
-        className={[styles.listGrid[size], styles.unorderedList]}
-        component="ul"
-      >
-        {children}
-      </Box>
-    ),
+    ul: ({ children }) => <UnorderedList size={size}>{children}</UnorderedList>,
     wrapper: ({ children }) => <Wrapper size={size}>{children}</Wrapper>,
   };
 };


### PR DESCRIPTION
I'm planning to revise these so there is some semblance of semantic correctness; the CSS Grid approach weaves a bunch of `<span>`s between the `<li>`s. This is just a small refactor to precede that.