### PR TITLE
chore: Update stale image snapshot

### DIFF
--- a/.loki/reference/chrome_laptop_MdxProvider_ImagesInternal.png
+++ b/.loki/reference/chrome_laptop_MdxProvider_ImagesInternal.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:273c3f411395991d798dc645ddef1b14945289cf8fb0136b4f11f098331892b9
-size 190720
+oid sha256:8035e1f53d7fbc5da62c94b77535efaaaa2b2328c813be9e9193914da89bd74a
+size 190445


### PR DESCRIPTION
This was from the margin fix in #46.