### PR TITLE
fix(List): Improve markup semantics

### DIFF
--- a/.loki/reference/chrome_laptop_MdxProvider_Combination.png
+++ b/.loki/reference/chrome_laptop_MdxProvider_Combination.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:16fca18ccfa77d482dfbcb08ae074c82965e454637aa26d915d9a1783841d255
-size 32182
+oid sha256:f200bd75c6116a7393308496ba44aa857d7d8edf55de845c92f9c35beedcfcd1
+size 32663

--- a/.loki/reference/chrome_laptop_MdxProvider_Lists.png
+++ b/.loki/reference/chrome_laptop_MdxProvider_Lists.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d855daa1f4a2684824f82d65a64d66bc27ee47dd0b090e50d702b30af2ce74b5
-size 66790
+oid sha256:d7208be5ed4f1696da4949c8c8c7afc61402fb0fefc4e0244b17345f8843ae3e
+size 98153

--- a/src/private/List.treat.ts
+++ b/src/private/List.treat.ts
@@ -2,13 +2,40 @@ import { Style, style, styleMap } from 'sku/treat';
 
 import { SIZES, SIZE_TO_PADDING, SIZE_TO_SPACE, Size } from './size';
 
-export const listGrid = styleMap<Size>((theme) =>
+export const listTable = style({
+  borderCollapse: 'separate',
+  borderSpacing: 0,
+  display: 'table',
+});
+
+export const listTableRow = style({
+  display: 'table-row',
+});
+
+export const listTableCell = styleMap<Size>((theme) =>
   SIZES.reduce<Record<Size, Style>>((acc, size) => {
     acc[size] = {
-      display: 'grid',
-      gridColumnGap: theme.grid * theme.space[SIZE_TO_PADDING[size]],
-      gridRowGap: theme.grid * theme.space[SIZE_TO_SPACE[size]],
-      gridTemplateColumns: 'min-content minmax(0, 1fr)',
+      borderBottomColor: 'transparent',
+      borderBottomStyle: 'solid',
+      borderBottomWidth: theme.grid * theme.space[SIZE_TO_SPACE[size]],
+      borderRightColor: 'transparent',
+      borderRightStyle: 'solid',
+      borderRightWidth: theme.grid * theme.space[SIZE_TO_PADDING[size]],
+      display: 'table-cell',
+      overflowWrap: 'anywhere',
+      verticalAlign: 'top',
+
+      selectors: {
+        '&:first-child': {
+          whiteSpace: 'nowrap',
+        },
+        '&:last-child': {
+          borderRightWidth: 0,
+        },
+        'li:last-child > &': {
+          borderBottomWidth: 0,
+        },
+      },
     };
 
     return acc;
@@ -26,17 +53,18 @@ export const unorderedList = style({
 export const listItem = style({
   display: 'list-item',
   textAlign: 'right',
+
   selectors: {
-    [`${orderedList} > span > &, ${orderedList} > div > div > span > &:before`]: {
+    [`${orderedList} > li > div > span > &, ${orderedList} > div > div > li > div > span > &:before`]: {
       counterIncrement: 'ol',
     },
-    [`${orderedList} > span > &:before, ${orderedList} > div > div > span > &:before`]: {
+    [`${orderedList} > li > div > span > &:before, ${orderedList} > div > div > li > div > span > &:before`]: {
       content: "counter(ol) '.'",
     },
-    [`${unorderedList} > span > &:before, ${unorderedList} > div > div > span > &:before`]: {
+    [`${unorderedList} > li > div > span > &:before, ${unorderedList} > div > div > li > div > span > &:before`]: {
       content: "'•'",
     },
-    [`${unorderedList} > span > &, ${unorderedList} > div > div > span > &`]: {
+    [`${unorderedList} > li > div > span > &, ${unorderedList} > div > div > li > div > span > &`]: {
       transform: 'scale(1.25)',
     },
   },

--- a/src/private/List.tsx
+++ b/src/private/List.tsx
@@ -1,5 +1,5 @@
 import { Box, Stack, Text } from 'braid-design-system';
-import React, { ComponentProps, Fragment } from 'react';
+import React, { ComponentProps } from 'react';
 import { useStyles } from 'sku/react-treat';
 
 import { SIZE_TO_SPACE, Size } from './size';
@@ -16,35 +16,34 @@ export const ListItem = ({ children, size }: Props) => {
   const space = SIZE_TO_SPACE[size];
 
   return (
-    <Fragment>
-      <Text size={size}>
-        <Box className={styles.listItem} />
-      </Text>
-      <Box component="li">
+    <Box className={styles.listTableRow} component="li">
+      <Box className={styles.listTableCell[size]}>
+        <Text size={size}>
+          <Box className={styles.listItem} />
+        </Text>
+      </Box>
+      <Box className={styles.listTableCell[size]}>
         <Stack space={space}>{children}</Stack>
       </Box>
-    </Fragment>
+    </Box>
   );
 };
 
-export const OrderedList = ({ children, size }: Props) => {
+export const OrderedList = ({ children }: Props) => {
   const styles = useStyles(styleRefs);
 
   return (
-    <Box className={[styles.listGrid[size], styles.orderedList]} component="ol">
+    <Box className={[styles.listTable, styles.orderedList]} component="ol">
       {children}
     </Box>
   );
 };
 
-export const UnorderedList = ({ children, size }: Props) => {
+export const UnorderedList = ({ children }: Props) => {
   const styles = useStyles(styleRefs);
 
   return (
-    <Box
-      className={[styles.listGrid[size], styles.unorderedList]}
-      component="ul"
-    >
+    <Box className={[styles.listTable, styles.unorderedList]} component="ul">
       {children}
     </Box>
   );

--- a/src/stories/markdowns/lists.mdx
+++ b/src/stories/markdowns/lists.mdx
@@ -1,3 +1,35 @@
+A loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong line
+
+---
+
+- A long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long line
+
+- A loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong line
+
+- Before
+
+  | 2   | 1                                                                                                                                                                                              |
+  | :-- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+  | B   | A loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong line |
+
+  After
+
+---
+
+1. A long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long line
+
+1. A loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong line
+
+1. Before
+
+   | 2   | 1                                                                                                                                                                                              |
+   | :-- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+   | B   | A loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong line |
+
+   After
+
+---
+
 1. First item
 2. Second item
 3. Third item


### PR DESCRIPTION
The CSS Grid implementation was nice to work with, but it was gross in that it weaved in `<span>`s:

```html
<ul>
  <span>bullet or number here</span>
  <li>actual list item here</li>
</ul>
```

This is a shot at a CSS Table implementation where the `<li>` can be modelled as a table row and contain both the bullet/number and content as cells.

The blocker currently is that I can't figure out how to elegantly stop the table from overflowing its parent. An aggressive `overflow-wrap` gets us most of the way there, but it means that table overflow behaviour is different inside and outside of a list, and it doesn't work at all for `CodeBlock`s.