### PR TITLE
fix(List): Align and round bullets better

### DIFF
--- a/.loki/reference/chrome_laptop_MdxProvider_Lists.png
+++ b/.loki/reference/chrome_laptop_MdxProvider_Lists.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:db10209b449702b47a18a4a21ba8074de13bdc8974186a7b97a09cecaaadf27e
-size 71263
+oid sha256:e4574977c08ea89207640b87751c6f697061ce13e81968a4edbe259a3f56dbec
+size 70975

--- a/.loki/reference/chrome_laptop_MdxProvider_Table.png
+++ b/.loki/reference/chrome_laptop_MdxProvider_Table.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5ef9b2334711aeef1db6ac45fb01747086ce08d236d986c64be9a88fb8b55018
-size 38903
+oid sha256:554eef4561cf0f10de0d7cefd8982a3955a78341b56993b200ef54e850f4d303
+size 38865

--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -13,7 +13,7 @@ import { PrismAsyncLight as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { ghcolors } from 'react-syntax-highlighter/dist/cjs/styles/prism';
 import { useStyles } from 'sku/react-treat';
 
-import { SIZE_TO_CODE_SIZE, Size } from '../private/size';
+import { DEFAULT_SIZE, SIZE_TO_CODE_SIZE, Size } from '../private/size';
 
 import * as styleRefs from './CodeBlock.treat';
 
@@ -152,7 +152,7 @@ export const CodeBlock = ({
   children,
   language = 'text',
   graphqlPlayground,
-  size = 'standard',
+  size = DEFAULT_SIZE,
 }: {
   children: string;
   language: string;

--- a/src/components/MdxProvider.tsx
+++ b/src/components/MdxProvider.tsx
@@ -2,7 +2,7 @@ import { MDXProvider } from '@mdx-js/react';
 import React from 'react';
 
 import { GraphQLPlaygroundProvider } from '../private/hooks/graphqlPlayground';
-import { Size } from '../private/size';
+import { DEFAULT_SIZE, Size } from '../private/size';
 import { useMdxComponents } from '../private/useMdxComponents';
 
 interface MdxProviderProps {
@@ -22,7 +22,7 @@ interface MdxProviderProps {
 export const MdxProvider: React.FunctionComponent<MdxProviderProps> = ({
   children,
   graphqlPlayground,
-  size = 'standard',
+  size = DEFAULT_SIZE,
 }) => {
   const components = useMdxComponents({ size });
 

--- a/src/components/WrapperRenderer.tsx
+++ b/src/components/WrapperRenderer.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { WrapperComponent } from '../private/Wrapper';
+import { DEFAULT_SIZE } from '../private/size';
 import { useMdxWrapper } from '../private/useMdxWrapper';
 
 export const WrapperRenderer = ({
@@ -12,7 +13,7 @@ export const WrapperRenderer = ({
 }) => {
   // The built-in wrapper size doesn't really matter here as the provided
   // component can overwrite it.
-  const wrapper = useMdxWrapper(children, 'standard');
+  const wrapper = useMdxWrapper(children, DEFAULT_SIZE);
 
   return (
     <Document

--- a/src/private/List.treat.ts
+++ b/src/private/List.treat.ts
@@ -2,6 +2,23 @@ import { Style, style, styleMap } from 'sku/treat';
 
 import { SIZES, SIZE_TO_PADDING, SIZE_TO_SPACE, Size } from './size';
 
+const COUNTER_NAME = 'scoobie-ordered-list';
+
+export const bulletColor = style({
+  backgroundColor: 'currentColor',
+});
+
+export const bulletSize = {
+  standard: style({
+    width: 4,
+    height: 4,
+  }),
+  large: style({
+    width: 5,
+    height: 5,
+  }),
+};
+
 export const listGrid = styleMap<Size>((theme) =>
   SIZES.reduce<Record<Size, Style>>((acc, size) => {
     acc[size] = {
@@ -16,28 +33,37 @@ export const listGrid = styleMap<Size>((theme) =>
 );
 
 export const orderedList = style({
-  counterReset: 'ol',
+  counterReset: COUNTER_NAME,
 });
 
 export const unorderedList = style({
-  counterReset: 'ol',
+  counterReset: COUNTER_NAME,
 });
 
 export const listItem = style({
   display: 'list-item',
   textAlign: 'right',
-  selectors: {
-    [`${orderedList} > span > &, ${orderedList} > div > div > span > &:before`]: {
-      counterIncrement: 'ol',
-    },
-    [`${orderedList} > span > &:before, ${orderedList} > div > div > span > &:before`]: {
-      content: "counter(ol) '.'",
-    },
-    [`${unorderedList} > span > &:before, ${unorderedList} > div > div > span > &:before`]: {
-      content: "'•'",
-    },
-    [`${unorderedList} > span > &, ${unorderedList} > div > div > span > &`]: {
-      transform: 'scale(1.25)',
-    },
+});
+
+export const orderedListItem = style({
+  counterIncrement: COUNTER_NAME,
+
+  ':before': {
+    content: `counter(${COUNTER_NAME}) '.'`,
   },
 });
+
+export const unorderedListItem = styleMap<Size>((theme) =>
+  SIZES.reduce<Record<Size, Style>>((acc, size) => {
+    acc[size] = theme.utils.responsiveStyle({
+      mobile: {
+        height: theme.grid * theme.typography.text[size].mobile.rows,
+      },
+      tablet: {
+        height: theme.grid * theme.typography.text[size].tablet.rows,
+      },
+    });
+
+    return acc;
+  }, {} as Record<Size, Style>),
+);

--- a/src/private/List.treat.ts
+++ b/src/private/List.treat.ts
@@ -40,13 +40,10 @@ export const unorderedList = style({
   counterReset: COUNTER_NAME,
 });
 
-export const listItem = style({
-  display: 'list-item',
-  textAlign: 'right',
-});
-
 export const orderedListItem = style({
   counterIncrement: COUNTER_NAME,
+  display: 'list-item',
+  textAlign: 'right',
 
   ':before': {
     content: `counter(${COUNTER_NAME}) '.'`,

--- a/src/private/List.tsx
+++ b/src/private/List.tsx
@@ -1,16 +1,36 @@
 import { Box, Stack, Text } from 'braid-design-system';
-import React, { ComponentProps, Fragment } from 'react';
+import React, {
+  ComponentProps,
+  Fragment,
+  ReactNode,
+  createContext,
+  useContext,
+} from 'react';
 import { useStyles } from 'sku/react-treat';
 
-import { SIZE_TO_SPACE, Size } from './size';
+import { DEFAULT_SIZE, SIZE_TO_SPACE, Size } from './size';
 
 import * as styleRefs from './List.treat';
 
-type Props = Pick<ComponentProps<typeof Stack>, 'children'> & {
+interface ListContextValue {
   size: Size;
-};
+  type: ListType;
+}
 
-export const ListItem = ({ children, size }: Props) => {
+type ListType = 'ordered' | 'unordered';
+
+const DEFAULT_TYPE: ListType = 'unordered';
+
+const ListContext = createContext<ListContextValue>({
+  size: DEFAULT_SIZE,
+  type: DEFAULT_TYPE,
+});
+
+type ListItemProps = Pick<ComponentProps<typeof Stack>, 'children'>;
+
+export const ListItem = ({ children }: ListItemProps) => {
+  const { size, type } = useContext(ListContext);
+
   const styles = useStyles(styleRefs);
 
   const space = SIZE_TO_SPACE[size];
@@ -18,8 +38,24 @@ export const ListItem = ({ children, size }: Props) => {
   return (
     <Fragment>
       <Text size={size}>
-        <Box className={styles.listItem} />
+        {type === 'ordered' ? (
+          <Box className={[styles.listItem, styles.orderedListItem]} />
+        ) : (
+          <Box className={styles.listItem}>
+            <Box
+              alignItems="center"
+              className={styles.unorderedListItem[size]}
+              display="flex"
+            >
+              <Box
+                borderRadius="full"
+                className={[styles.bulletColor, styles.bulletSize[size]]}
+              />
+            </Box>
+          </Box>
+        )}
       </Text>
+
       <Box component="li">
         <Stack space={space}>{children}</Stack>
       </Box>
@@ -27,25 +63,47 @@ export const ListItem = ({ children, size }: Props) => {
   );
 };
 
-export const OrderedList = ({ children, size }: Props) => {
+interface ListProps {
+  children: ReactNode;
+  size?: Size;
+}
+
+export const OrderedList = ({ children, size = DEFAULT_SIZE }: ListProps) => {
   const styles = useStyles(styleRefs);
 
   return (
-    <Box className={[styles.listGrid[size], styles.orderedList]} component="ol">
-      {children}
-    </Box>
+    <ListContext.Provider
+      value={{
+        size,
+        type: 'ordered',
+      }}
+    >
+      <Box
+        className={[styles.listGrid[size], styles.orderedList]}
+        component="ol"
+      >
+        {children}
+      </Box>
+    </ListContext.Provider>
   );
 };
 
-export const UnorderedList = ({ children, size }: Props) => {
+export const UnorderedList = ({ children, size = DEFAULT_SIZE }: ListProps) => {
   const styles = useStyles(styleRefs);
 
   return (
-    <Box
-      className={[styles.listGrid[size], styles.unorderedList]}
-      component="ul"
+    <ListContext.Provider
+      value={{
+        size,
+        type: 'unordered',
+      }}
     >
-      {children}
-    </Box>
+      <Box
+        className={[styles.listGrid[size], styles.unorderedList]}
+        component="ul"
+      >
+        {children}
+      </Box>
+    </ListContext.Provider>
   );
 };

--- a/src/private/List.tsx
+++ b/src/private/List.tsx
@@ -39,19 +39,17 @@ export const ListItem = ({ children }: ListItemProps) => {
     <Fragment>
       <Text size={size}>
         {type === 'ordered' ? (
-          <Box className={[styles.listItem, styles.orderedListItem]} />
+          <Box className={styles.orderedListItem} />
         ) : (
-          <Box className={styles.listItem}>
+          <Box
+            alignItems="center"
+            className={styles.unorderedListItem[size]}
+            display="flex"
+          >
             <Box
-              alignItems="center"
-              className={styles.unorderedListItem[size]}
-              display="flex"
-            >
-              <Box
-                borderRadius="full"
-                className={[styles.bulletColor, styles.bulletSize[size]]}
-              />
-            </Box>
+              borderRadius="full"
+              className={[styles.bulletColor, styles.bulletSize[size]]}
+            />
           </Box>
         )}
       </Text>

--- a/src/private/size.ts
+++ b/src/private/size.ts
@@ -6,6 +6,8 @@ type Space = 'medium' | 'large';
 
 export type Size = typeof SIZES[number];
 
+export const DEFAULT_SIZE: Size = 'standard';
+
 export const SIZES = ['standard', 'large'] as const;
 
 export const SIZE_TO_CODE_SIZE: Record<Size, CodeSize> = {

--- a/src/private/useMdxComponents.tsx
+++ b/src/private/useMdxComponents.tsx
@@ -48,7 +48,7 @@ export const useMdxComponents = ({ size }: Props): MDX.ProviderComponents => {
     img: (props) => (
       <Box {...props} className={imageStyles.img} component="img" />
     ),
-    li: ({ children }) => <ListItem size={size}>{children}</ListItem>,
+    li: ListItem,
     ol: ({ children }) => <OrderedList size={size}>{children}</OrderedList>,
     // Don't try to be clever here, this is what you want. No, really. `Text`
     // renders inline formatting correctly and fixes the line height. If some

--- a/src/stories/decorator.tsx
+++ b/src/stories/decorator.tsx
@@ -7,6 +7,8 @@ import { addDecorator } from 'sku/@storybook/react';
 import { MdxProvider } from 'src';
 import { robotoHref, robotoMonoHref } from 'typography';
 
+import { DEFAULT_SIZE, SIZES } from 'src/private/size';
+
 type DecoratorFunction = Parameters<typeof addDecorator>[0];
 
 export const withBraid: DecoratorFunction = (story) => (
@@ -34,11 +36,7 @@ export const withBraid: DecoratorFunction = (story) => (
           'https://graphql.seek.com/graphql',
         ) || undefined
       }
-      size={select(
-        'MdxProvider.size',
-        ['standard', 'large'] as const,
-        'standard',
-      )}
+      size={select('MdxProvider.size', SIZES, DEFAULT_SIZE)}
     >
       <BrowserRouter>
         <Helmet>


### PR DESCRIPTION
This steals Braid's Bullet implementation which solves our long-standing alignment woes. This requires us to differentiate between ordered and unordered list items. We now do this via React context, which happens to free us from CSS selector specificity migraines.