### PR TITLE
fix(List): Emit sensible HTML from ordered lists

### DIFF
--- a/src/private/List.treat.ts
+++ b/src/private/List.treat.ts
@@ -8,6 +8,21 @@ export const bulletColor = style({
   backgroundColor: 'currentColor',
 });
 
+export const bulletLineHeight = styleMap<Size>((theme) =>
+  SIZES.reduce<Record<Size, Style>>((acc, size) => {
+    acc[size] = theme.utils.responsiveStyle({
+      mobile: {
+        height: theme.grid * theme.typography.text[size].mobile.rows,
+      },
+      tablet: {
+        height: theme.grid * theme.typography.text[size].tablet.rows,
+      },
+    });
+
+    return acc;
+  }, {} as Record<Size, Style>),
+);
+
 export const bulletSize = {
   standard: style({
     width: 4,
@@ -32,11 +47,7 @@ export const listGrid = styleMap<Size>((theme) =>
   }, {} as Record<Size, Style>),
 );
 
-export const orderedList = style({
-  counterReset: COUNTER_NAME,
-});
-
-export const orderedListItem = style({
+export const numbering = style({
   counterIncrement: COUNTER_NAME,
   display: 'list-item',
   textAlign: 'right',
@@ -46,17 +57,10 @@ export const orderedListItem = style({
   },
 });
 
-export const unorderedListItem = styleMap<Size>((theme) =>
-  SIZES.reduce<Record<Size, Style>>((acc, size) => {
-    acc[size] = theme.utils.responsiveStyle({
-      mobile: {
-        height: theme.grid * theme.typography.text[size].mobile.rows,
-      },
-      tablet: {
-        height: theme.grid * theme.typography.text[size].tablet.rows,
-      },
-    });
+export const orderedList = style({
+  counterReset: COUNTER_NAME,
+});
 
-    return acc;
-  }, {} as Record<Size, Style>),
-);
+export const propagateGrid = style({
+  display: 'contents',
+});

--- a/src/private/List.treat.ts
+++ b/src/private/List.treat.ts
@@ -36,10 +36,6 @@ export const orderedList = style({
   counterReset: COUNTER_NAME,
 });
 
-export const unorderedList = style({
-  counterReset: COUNTER_NAME,
-});
-
 export const orderedListItem = style({
   counterIncrement: COUNTER_NAME,
   display: 'list-item',

--- a/src/private/List.tsx
+++ b/src/private/List.tsx
@@ -1,10 +1,5 @@
 import { Box, Stack, Text } from 'braid-design-system';
-import React, {
-  ComponentProps,
-  Fragment,
-  createContext,
-  useContext,
-} from 'react';
+import React, { ComponentProps, createContext, useContext } from 'react';
 import { useStyles } from 'sku/react-treat';
 
 import { DEFAULT_SIZE, SIZE_TO_PADDING, SIZE_TO_SPACE, Size } from './size';
@@ -36,27 +31,20 @@ export const ListItem = ({ children }: Props) => {
 
   const space = SIZE_TO_SPACE[size];
 
-  if (type === 'ordered') {
-    // TODO: consider subgrid/table for proper `<ul><li>...</li></ul> nesting
-    return (
-      <Fragment>
-        <Text size={size}>
-          <Box className={styles.orderedListItem} />
-        </Text>
+  return type === 'ordered' ? (
+    <Box component="li" className={styles.propagateGrid}>
+      <Text aria-hidden size={size}>
+        <Box className={styles.numbering} />
+      </Text>
 
-        <Box component="li">
-          <Stack space={space}>{children}</Stack>
-        </Box>
-      </Fragment>
-    );
-  }
-
-  return (
+      <Stack space={space}>{children}</Stack>
+    </Box>
+  ) : (
     <Box display="flex">
-      <Text size={size}>
+      <Text aria-hidden size={size}>
         <Box
           alignItems="center"
-          className={styles.unorderedListItem[size]}
+          className={styles.bulletLineHeight[size]}
           display="flex"
           paddingRight={SIZE_TO_PADDING[size]}
         >

--- a/src/private/List.tsx
+++ b/src/private/List.tsx
@@ -2,13 +2,12 @@ import { Box, Stack, Text } from 'braid-design-system';
 import React, {
   ComponentProps,
   Fragment,
-  ReactNode,
   createContext,
   useContext,
 } from 'react';
 import { useStyles } from 'sku/react-treat';
 
-import { DEFAULT_SIZE, SIZE_TO_SPACE, Size } from './size';
+import { DEFAULT_SIZE, SIZE_TO_PADDING, SIZE_TO_SPACE, Size } from './size';
 
 import * as styleRefs from './List.treat';
 
@@ -26,47 +25,54 @@ const ListContext = createContext<ListContextValue>({
   type: DEFAULT_TYPE,
 });
 
-type ListItemProps = Pick<ComponentProps<typeof Stack>, 'children'>;
+type Props = Pick<ComponentProps<typeof Stack>, 'children'> & {
+  size?: Size;
+};
 
-export const ListItem = ({ children }: ListItemProps) => {
+export const ListItem = ({ children }: Props) => {
   const { size, type } = useContext(ListContext);
 
   const styles = useStyles(styleRefs);
 
   const space = SIZE_TO_SPACE[size];
 
-  return (
-    <Fragment>
-      <Text size={size}>
-        {type === 'ordered' ? (
+  if (type === 'ordered') {
+    // TODO: consider subgrid/table for proper `<ul><li>...</li></ul> nesting
+    return (
+      <Fragment>
+        <Text size={size}>
           <Box className={styles.orderedListItem} />
-        ) : (
+        </Text>
+
+        <Box component="li">
+          <Stack space={space}>{children}</Stack>
+        </Box>
+      </Fragment>
+    );
+  }
+
+  return (
+    <Box display="flex">
+      <Text size={size}>
+        <Box
+          alignItems="center"
+          className={styles.unorderedListItem[size]}
+          display="flex"
+          paddingRight={SIZE_TO_PADDING[size]}
+        >
           <Box
-            alignItems="center"
-            className={styles.unorderedListItem[size]}
-            display="flex"
-          >
-            <Box
-              borderRadius="full"
-              className={[styles.bulletColor, styles.bulletSize[size]]}
-            />
-          </Box>
-        )}
+            borderRadius="full"
+            className={[styles.bulletColor, styles.bulletSize[size]]}
+          />
+        </Box>
       </Text>
 
-      <Box component="li">
-        <Stack space={space}>{children}</Stack>
-      </Box>
-    </Fragment>
+      <Stack space={space}>{children}</Stack>
+    </Box>
   );
 };
 
-interface ListProps {
-  children: ReactNode;
-  size?: Size;
-}
-
-export const OrderedList = ({ children, size = DEFAULT_SIZE }: ListProps) => {
+export const OrderedList = ({ children, size = DEFAULT_SIZE }: Props) => {
   const styles = useStyles(styleRefs);
 
   return (
@@ -86,22 +92,15 @@ export const OrderedList = ({ children, size = DEFAULT_SIZE }: ListProps) => {
   );
 };
 
-export const UnorderedList = ({ children, size = DEFAULT_SIZE }: ListProps) => {
-  const styles = useStyles(styleRefs);
-
-  return (
-    <ListContext.Provider
-      value={{
-        size,
-        type: 'unordered',
-      }}
-    >
-      <Box
-        className={[styles.listGrid[size], styles.unorderedList]}
-        component="ul"
-      >
-        {children}
-      </Box>
-    </ListContext.Provider>
-  );
-};
+export const UnorderedList = ({ children, size = DEFAULT_SIZE }: Props) => (
+  <ListContext.Provider
+    value={{
+      size,
+      type: 'unordered',
+    }}
+  >
+    <Stack component="ul" space={SIZE_TO_SPACE[size]}>
+      {children}
+    </Stack>
+  </ListContext.Provider>
+);


### PR DESCRIPTION
This uses `display: contents` to allow for nested children in a grid. This is better than invalid markup, but there are accessibility issues with the implementation in most browsers :(

https://hiddedevries.nl/en/blog/2018-04-21-more-accessible-markup-with-display-contents