### PR TITLE
fix(CodeBlock): Load synchronously

### DIFF
--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -9,7 +9,7 @@ import {
   Text,
 } from 'braid-design-system';
 import React, { ReactNode, ReactNodeArray, useState } from 'react';
-import { PrismAsyncLight as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { PrismLight as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { ghcolors } from 'react-syntax-highlighter/dist/cjs/styles/prism';
 import { useStyles } from 'sku/react-treat';
 


### PR DESCRIPTION
The async Prism implementation grants a smaller bundle size upfront, but it also seems to defer rendering of our code block container styling. This manifests as ugly pop in which is not present when using the sync version.