### PR TITLE
feat(MdxProvider): Add link title support

### DIFF
--- a/src/private/useMdxComponents.tsx
+++ b/src/private/useMdxComponents.tsx
@@ -28,7 +28,14 @@ export const useMdxComponents = ({ size }: Props): MDX.ProviderComponents => {
   const space = SIZE_TO_SPACE[size];
 
   return {
-    a: SmartTextLink,
+    a: ({ title, ...props }) =>
+      title ? (
+        <Box component="span" title={title}>
+          <SmartTextLink {...props} />
+        </Box>
+      ) : (
+        <SmartTextLink {...props} />
+      ),
     blockquote: ({ children }) => (
       <Blockquote size={size}>{children}</Blockquote>
     ),

--- a/types.d.ts
+++ b/types.d.ts
@@ -24,7 +24,7 @@ declare namespace MDX {
   >;
 
   type ProviderComponents = Partial<{
-    a: ProviderComponent<{ href: string }>;
+    a: ProviderComponent<{ href: string; title?: string }>;
     blockquote: ProviderComponent;
     code: ProviderComponent<{ className?: string }>;
     delete: ProviderComponent;


### PR DESCRIPTION
This supports the optional title on Markdown links, e.g.

```markdown
My favorite search engine is [Duck Duck Go](https://duckduckgo.com "The best search engine for privacy").
```

This handles the title directly in `useMdxComponents` instead of adding support to `<SmartTextLink>`. It seems more Braid-y to make the consumer compose the component with a `Box` to get a title.