### PR TITLE
feat(CodeBlock): Support multiple tabs

### DIFF
--- a/.loki/reference/chrome_laptop_CodeBlock_Custom.png
+++ b/.loki/reference/chrome_laptop_CodeBlock_Custom.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9fcf1b46fdfba28018fa77d243e9a460a26d3b095190bec240d0979573b989d1
-size 5267

--- a/.loki/reference/chrome_laptop_CodeBlock_Multi.png
+++ b/.loki/reference/chrome_laptop_CodeBlock_Multi.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:13e585ba8ef4437402ed0055e7ae5093b4b545c5b5396fb1a5ff5b9eab8f48d6
+size 10628

--- a/.loki/reference/chrome_laptop_CodeBlock_Single.png
+++ b/.loki/reference/chrome_laptop_CodeBlock_Single.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:543919698306e81e64ba4a7e68d60fde9d1af23242f9055f1b33bb55b5b8d8fa
+size 9232

--- a/.loki/reference/chrome_laptop_MdxProvider_Code.png
+++ b/.loki/reference/chrome_laptop_MdxProvider_Code.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c1c85a3a1cbf95423dd3742258671ca22356c4fba13823ded5ca21f24c950dc3
-size 202103
+oid sha256:2b43a05e59d761508f3d5eb8e376c2392e7d0653a764493796c9f9ef3e2c4663
+size 249816

--- a/.loki/reference/chrome_laptop_MdxProvider_Combination.png
+++ b/.loki/reference/chrome_laptop_MdxProvider_Combination.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:101f171f5685939178a50b1e2fca8ab33468d4242c1830c9c4e4fb86295aea50
-size 31923
+oid sha256:892b9de26dc6b37a67d5cbee7f74e52f30c4fb4c7d5e74811bb1eb0b5880f081
+size 33877

--- a/src/components/CodeBlock.treat.ts
+++ b/src/components/CodeBlock.treat.ts
@@ -5,8 +5,6 @@ import { Theme } from 'treat/theme';
 import { CODE_SIZES, CodeSize } from '../private/size';
 import { monospaceFontStyles } from '../styles';
 
-export const codeBlock = style({});
-
 export const lineNumberContainer = style((theme) => ({
   backgroundColor: darken(0.05, theme.color.background.body),
   borderTopLeftRadius: theme.border.radius.standard,
@@ -19,45 +17,6 @@ export const code = styleMap<CodeSize>((theme) => ({
   small: monospaceFontStyles(theme, 'small'),
   standard: monospaceFontStyles(theme, 'standard'),
 }));
-
-export const buttonOuter = style((theme) => ({
-  borderColor: darken(0.05, theme.color.background.body),
-  borderStyle: 'solid',
-  borderWidth: theme.border.width.standard,
-  ':hover': {
-    cursor: 'pointer',
-  },
-
-  ...theme.utils.responsiveStyle({
-    desktop: {
-      opacity: 0,
-      selectors: {
-        [`${codeBlock}:hover &`]: {
-          opacity: 1,
-        },
-      },
-    },
-    mobile: {
-      opacity: 1,
-    },
-  }),
-}));
-
-export const buttonInner = style((theme) =>
-  theme.utils.responsiveStyle({
-    desktop: {
-      opacity: 0.5,
-      selectors: {
-        [`${buttonOuter}:hover &`]: {
-          opacity: 1,
-        },
-      },
-    },
-    mobile: {
-      opacity: 1,
-    },
-  }),
-);
 
 const fit30LinesOfCode = (theme: Theme, codeSize: CodeSize) =>
   theme.utils.responsiveStyle({

--- a/src/private/Prism.ts
+++ b/src/private/Prism.ts
@@ -10,7 +10,20 @@ splunkSplLang(Prism);
 export { Prism } from 'prism-react-renderer';
 export { default as prismTheme } from 'prism-react-renderer/themes/github';
 
-const CODE_LANGUAGE_REPLACEMENTS: Record<string, string> = {
+const DISPLAY_LANGUAGE_REPLACEMENTS: Record<string, string> = {
+  'splunk-spl': 'Splunk SPL',
+  bash: 'Bash',
+  csharp: 'C#',
+  graphql: 'GraphQL',
+  go: 'Go',
+  markdown: 'Markdown',
+  javascript: 'JavaScript',
+  typescript: 'TypeScript',
+  text: 'Text',
+};
+
+const PRISM_LANGUAGE_REPLACEMENTS: Record<string, string> = {
+  'c#': 'csharp',
   gql: 'graphql',
   js: 'javascript',
   jsonc: 'json',
@@ -20,6 +33,15 @@ const CODE_LANGUAGE_REPLACEMENTS: Record<string, string> = {
   ts: 'typescript',
 };
 
-// The Language type is pointless. We extend it, and there is a fallback anyway.
-export const prismLanguage = (language: string) =>
-  (CODE_LANGUAGE_REPLACEMENTS[language] ?? language) as Language;
+export const displayLanguage = (language: string) => {
+  const prism = prismLanguage(language);
+
+  return DISPLAY_LANGUAGE_REPLACEMENTS[prism] ?? prism.toLocaleUpperCase();
+};
+
+export const prismLanguage = (language: string) => {
+  const lower = language.toLocaleLowerCase();
+
+  // This type is pointless. We extend it and there is a fallback anyway.
+  return (PRISM_LANGUAGE_REPLACEMENTS[lower] ?? lower) as Language;
+};

--- a/src/private/ScrollableInline.treat.ts
+++ b/src/private/ScrollableInline.treat.ts
@@ -1,0 +1,10 @@
+import { style } from 'sku/treat';
+
+export const nowrap = style({
+  whiteSpace: 'nowrap',
+});
+
+export const overflowX = style({
+  overflowX: 'auto',
+  overflowY: 'hidden',
+});

--- a/src/private/ScrollableInline.tsx
+++ b/src/private/ScrollableInline.tsx
@@ -1,0 +1,21 @@
+import { Box } from 'braid-design-system';
+import React, { ReactNode } from 'react';
+import { useStyles } from 'sku/react-treat';
+
+import * as styleRefs from './ScrollableInline.treat';
+
+interface Props {
+  children: ReactNode;
+}
+
+export const ScrollableInline = ({ children }: Props) => {
+  const styles = useStyles(styleRefs);
+
+  return (
+    <Box className={styles.overflowX}>
+      <Box className={styles.nowrap} display="inlineBlock" width="full">
+        {children}
+      </Box>
+    </Box>
+  );
+};

--- a/src/stories/index.stories.tsx
+++ b/src/stories/index.stories.tsx
@@ -44,7 +44,7 @@ storiesOf('Blockquote', module)
   .addDecorator(withBraid);
 
 storiesOf('CodeBlock', module)
-  .add('Custom', () => (
+  .add('Single', () => (
     <CodeBlock
       language={text('language', 'graphql')}
       graphqlPlayground={text(
@@ -54,6 +54,33 @@ storiesOf('CodeBlock', module)
       size={select('size', ['standard', 'large'], 'standard')}
     >
       {text('children', 'query {\n  version\n}\n')}
+    </CodeBlock>
+  ))
+  .add('Multi', () => (
+    <CodeBlock
+      graphqlPlayground={text(
+        'graphqlPlayground',
+        'https://graphql.seek.com/graphql',
+      )}
+      size={select('size', ['standard', 'large'], 'standard')}
+    >
+      {[
+        {
+          code: 'query {\n  version\n}\n',
+          label: 'Operation',
+          language: 'graphql',
+        },
+        {
+          code: '{}',
+          label: 'Variables',
+          language: 'jsonc',
+        },
+        {
+          code: '{\n  "data": null\n}\n',
+          label: 'Response',
+          language: 'jsonc',
+        },
+      ]}
     </CodeBlock>
   ))
   .addDecorator(withBraid);


### PR DESCRIPTION
CodeBlock can now take in and render a list of children. Potential uses:

- Display a code sample available across multiple languages
- Display a GraphQL operation, variables and response inline

The new layout affects all existing CodeBlocks:

- Language is now visible on the top left
- Actions are now always visible on the top right

I plan to make a subsequent change to the MDX pipeline to group adjacent code blocks and render them as a tabbed CodeBlock.