### PR TITLE
fix(CodeBlock): Loosen prop typings

### DIFF
--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -20,21 +20,13 @@ import { Lines } from './CodeBlock/Lines';
 
 import * as styleRefs from './CodeBlock.treat';
 
-type Props = {
+interface Props {
+  children: CodeChildProps[] | string;
   graphqlPlayground?: string;
+  label?: string;
+  language?: string;
   size?: Size;
-} & (
-  | {
-      children: string;
-      label?: string;
-      language?: string;
-    }
-  | {
-      children: CodeChildProps[];
-      label?: undefined;
-      language?: undefined;
-    }
-);
+}
 
 export const CodeBlock = ({
   children: rawChildren,


### PR DESCRIPTION
I was trying to be clever and prevent the shorthand `label` and `language` props from being provided alongside a complex `children`, but TypeScript doesn't seem to correctly infer this and throws false positives in consumer repositories.