### PR TITLE
fix(CodeBlock): Improve C# and Java

### DIFF
--- a/.loki/reference/chrome_laptop_MdxProvider_Combination.png
+++ b/.loki/reference/chrome_laptop_MdxProvider_Combination.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e58dd8c70fb8def3fb573b9998460a9352cf28bd8525f96088f6740e789113c0
-size 33729
+oid sha256:95a88bd67aa665720bd4b5e836f96af3f340f5ee5870d27eb85a69729c0db263
+size 42303

--- a/src/private/Prism.ts
+++ b/src/private/Prism.ts
@@ -1,9 +1,12 @@
 import { Language, Prism } from 'prism-react-renderer';
 // @ts-ignore
+import csharpLang from 'refractor/lang/csharp';
+// @ts-ignore
 import httpLang from 'refractor/lang/http';
 // @ts-ignore
 import splunkSplLang from 'refractor/lang/splunk-spl';
 
+csharpLang(Prism);
 httpLang(Prism);
 splunkSplLang(Prism);
 
@@ -16,12 +19,13 @@ const DISPLAY_LANGUAGE_REPLACEMENTS: Record<string, string> = {
   'splunk-spl': 'Splunk SPL',
   bash: 'Bash',
   csharp: 'C#',
-  graphql: 'GraphQL',
   go: 'Go',
-  markdown: 'Markdown',
+  graphql: 'GraphQL',
+  java: 'Java',
   javascript: 'JavaScript',
-  typescript: 'TypeScript',
+  markdown: 'Markdown',
   text: 'Text',
+  typescript: 'TypeScript',
 };
 
 const PRISM_LANGUAGE_REPLACEMENTS: Record<string, string> = {

--- a/src/stories/markdowns/combination.mdx
+++ b/src/stories/markdowns/combination.mdx
@@ -12,4 +12,12 @@ This section describes how to authenticate to the GraphQL endpoint using a partn
    fmt.Println("this line is loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong")
    ```
 
+4. ```c#
+   Console.WriteLine("shrt");
+   ```
+
+   ```java
+   System.out.println("shrt");
+   ```
+
 [bearer token]: https://tools.ietf.org/html/rfc6750#section-2.1


### PR DESCRIPTION
These are the enterprisiest languages so it's probable that we would provide some code samples in future.

- Register C# for highlighting
- Format Java display label

This also snapshots a short CodeBlock in a List to flag an existing issue. I believe it requires an upstream fix or some other workaround I haven't thought of yet.