### PR TITLE
feat(CodeBlock): Allow trimming to be disabled

### DIFF
--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -26,6 +26,7 @@ interface Props {
   label?: string;
   language?: string;
   size?: Size;
+  trim?: boolean;
 }
 
 export const CodeBlock = ({
@@ -34,6 +35,7 @@ export const CodeBlock = ({
   language: rawLanguage,
   graphqlPlayground,
   size = DEFAULT_SIZE,
+  trim = true,
 }: Props) => {
   const styles = useStyles(styleRefs);
 
@@ -47,6 +49,7 @@ export const CodeBlock = ({
           },
         ]
       : rawChildren,
+    trim,
   );
 
   const codeSize = SIZE_TO_CODE_SIZE[size];

--- a/src/components/CodeBlock/CodeChild.test.ts
+++ b/src/components/CodeBlock/CodeChild.test.ts
@@ -3,19 +3,22 @@ import { normaliseChildren } from './CodeChild';
 describe('normaliseChildren', () => {
   it('handles partial props', () =>
     expect(
-      normaliseChildren([
-        {
-          code: '1',
-        },
-        {
-          code: '2',
-          language: 'gQL',
-        },
-        {
-          code: '3',
-          label: 'Gql',
-        },
-      ]),
+      normaliseChildren(
+        [
+          {
+            code: '  1',
+          },
+          {
+            code: '2  ',
+            language: 'gQL',
+          },
+          {
+            code: '\n3\n',
+            label: 'Gql',
+          },
+        ],
+        true,
+      ),
     ).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -36,18 +39,61 @@ describe('normaliseChildren', () => {
       ]
     `));
 
+  it('handles disabled trimming', () =>
+    expect(
+      normaliseChildren(
+        [
+          {
+            code: '  1',
+          },
+          {
+            code: '2  ',
+            language: 'gQL',
+          },
+          {
+            code: '\n3\n',
+            label: 'Gql',
+          },
+        ],
+        false,
+      ),
+    ).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "code": "  1",
+          "label": "Text",
+          "language": "text",
+        },
+        Object {
+          "code": "2  ",
+          "label": "GraphQL",
+          "language": "graphql",
+        },
+        Object {
+          "code": "
+      3
+      ",
+          "label": "Gql",
+          "language": "text",
+        },
+      ]
+    `));
+
   it('infers GraphQL x2 labels', () =>
     expect(
-      normaliseChildren([
-        {
-          code: '1',
-          language: 'graphql',
-        },
-        {
-          code: '2',
-          language: 'json',
-        },
-      ]),
+      normaliseChildren(
+        [
+          {
+            code: '1',
+            language: 'graphql',
+          },
+          {
+            code: '2',
+            language: 'json',
+          },
+        ],
+        true,
+      ),
     ).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -65,20 +111,23 @@ describe('normaliseChildren', () => {
 
   it('infers GraphQL x3 labels', () =>
     expect(
-      normaliseChildren([
-        {
-          code: '1',
-          language: 'graphql',
-        },
-        {
-          code: '2',
-          language: 'json',
-        },
-        {
-          code: '3',
-          language: 'json',
-        },
-      ]),
+      normaliseChildren(
+        [
+          {
+            code: '1',
+            language: 'graphql',
+          },
+          {
+            code: '2',
+            language: 'json',
+          },
+          {
+            code: '3',
+            language: 'json',
+          },
+        ],
+        true,
+      ),
     ).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -101,16 +150,19 @@ describe('normaliseChildren', () => {
 
   it('infers HTTP labels', () =>
     expect(
-      normaliseChildren([
-        {
-          code: '1',
-          language: 'http',
-        },
-        {
-          code: '2',
-          language: 'http',
-        },
-      ]),
+      normaliseChildren(
+        [
+          {
+            code: '1',
+            language: 'http',
+          },
+          {
+            code: '2',
+            language: 'http',
+          },
+        ],
+        true,
+      ),
     ).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -128,18 +180,21 @@ describe('normaliseChildren', () => {
 
   it('preserves unique labels', () =>
     expect(
-      normaliseChildren([
-        {
-          code: '1',
-          language: 'http',
-          label: 'Response',
-        },
-        {
-          code: '2',
-          language: 'http',
-          label: 'Request',
-        },
-      ]),
+      normaliseChildren(
+        [
+          {
+            code: '1',
+            language: 'http',
+            label: 'Response',
+          },
+          {
+            code: '2',
+            language: 'http',
+            label: 'Request',
+          },
+        ],
+        true,
+      ),
     ).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -157,24 +212,27 @@ describe('normaliseChildren', () => {
 
   it('overwrites non-unique labels', () =>
     expect(
-      normaliseChildren([
-        {
-          code: '1',
-          label: 'Response',
-        },
-        {
-          code: '2',
-          label: 'Response',
-        },
-        {
-          code: '3',
-          label: 'Response 1',
-        },
-        {
-          code: '4',
-          label: 'Response 1 1',
-        },
-      ]),
+      normaliseChildren(
+        [
+          {
+            code: '1',
+            label: 'Response',
+          },
+          {
+            code: '2',
+            label: 'Response',
+          },
+          {
+            code: '3',
+            label: 'Response 1',
+          },
+          {
+            code: '4',
+            label: 'Response 1 1',
+          },
+        ],
+        true,
+      ),
     ).toMatchInlineSnapshot(`
       Array [
         Object {

--- a/src/components/CodeBlock/CodeChild.tsx
+++ b/src/components/CodeBlock/CodeChild.tsx
@@ -129,9 +129,12 @@ const labeller = createLabeller(
  * - Infer label based on language(s)
  * - Ensure label uniqueness
  */
-export const normaliseChildren = (rawChildren: CodeChildProps[]) => {
+export const normaliseChildren = (
+  rawChildren: CodeChildProps[],
+  trim: boolean,
+) => {
   const children = rawChildren.map((child) => ({
-    code: child.code.trim(),
+    code: trim ? child.code.trim() : child.code,
     label: child.label,
     language: prismLanguage(child.language),
   }));

--- a/src/stories/index.stories.tsx
+++ b/src/stories/index.stories.tsx
@@ -53,6 +53,7 @@ storiesOf('CodeBlock', module)
         'https://graphql.seek.com/graphql',
       )}
       size={select('size', ['standard', 'large'], 'standard')}
+      trim={boolean('trim', true)}
     >
       {text('children', 'query {\n  version\n}\n')}
     </CodeBlock>
@@ -64,6 +65,7 @@ storiesOf('CodeBlock', module)
         'https://graphql.seek.com/graphql',
       )}
       size={select('size', ['standard', 'large'], 'standard')}
+      trim={boolean('trim', true)}
     >
       {[
         {


### PR DESCRIPTION
This is useful if you're intentionally inserting leading or trailing negative space into your code. An example of this is rendering a snippet of indented code.