### PR TITLE
feat(ScoobieLink): Add component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ npm-debug.log
 # managed by sku
 .eslintrc
 .prettierrc
-.ssl
 coverage/
 dist-playroom/
 dist-storybook/

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ yarn add --exact scoobie
   - [InlineCode](#inlinecode)
   - [InternalLink](#internallink)
   - [MdxProvider](#mdxprovider)
+  - [ScoobieLink](#scoobielink)
   - [SmartTextLink](#smarttextlink)
   - [Table](#table)
   - [TableRow](#tablerow)
@@ -131,18 +132,19 @@ Nest your Markdown components within an [MdxProvider](#mdxprovider):
 ```tsx
 import 'braid-design-system/reset';
 
-import { BraidLoadableProvider } from 'braid-design-system';
+import { BraidProvider } from 'braid-design-system';
+import apacTheme from 'braid-design-system/themes/apac';
 import React from 'react';
-import { MdxProvider } from 'scoobie';
+import { MdxProvider, ScoobieLink } from 'scoobie';
 
 import { ContentWithPointlessDiv } from './SomeFile.tsx';
 
-export const App = ({ site }: { site: string }) => (
-  <BraidLoadableProvider themeName={site}>
+export const App = () => (
+  <BraidProvider linkComponent={ScoobieLink} theme={apacTheme}>
     <MdxProvider>
       <ContentWithPointlessDiv />
     </MdxProvider>
-  </BraidLoadableProvider>
+  </BraidProvider>
 );
 ```
 
@@ -280,11 +282,11 @@ Render an internal link with the same opinions as our [MdxProvider](#mdxprovider
 - Internal links use client-side navigation with smooth scrolling via [react-router-hash-link],
   and pass through the `v` URL parameter for UI version switching
 
-Unlike [SmartTextLink](#smarttextlink), this is not bound to a parent [Text] as it has no underlying [TextLinkRenderer].
+Unlike [SmartTextLink](#smarttextlink), this is not bound to a parent [Text] as it has no underlying [TextLink].
 It can be used to make complex components navigable rather than just sections of text.
 
 [text]: https://seek-oss.github.io/braid-design-system/components/Text/
-[textlinkrenderer]: https://seek-oss.github.io/braid-design-system/components/TextLinkRenderer/
+[textlink]: https://seek-oss.github.io/braid-design-system/components/TextLink/
 
 ```tsx
 import { Stack, Text } from 'braid-design-system';
@@ -305,33 +307,56 @@ export const SomeComplexLinkElement = () => (
 ### MdxProvider
 
 Provide a base collection of [Braid]-styled renderers for child MDX documents.
+This expects with [ScoobieLink](#scoobielink).
 
 ```tsx
-import 'braid-design-system/reset';
-
-import { BraidLoadableProvider, Card } from 'braid-design-system';
+import { BraidProvider, Card } from 'braid-design-system';
+import apacTheme from 'braid-design-system/themes/apac';
 import React from 'react';
-import { MdxProvider } from 'scoobie';
+import { MdxProvider, ScoobieLink } from 'scoobie';
 
 import Content from './Content.mdx';
 
-export const App = ({ site }: { site: string }) => (
-  <BraidLoadableProvider themeName={site}>
+export const Component = () => (
+  <BraidProvider linkComponent={ScoobieLink} theme={apacTheme}>
     <MdxProvider>
       <Card>
         <Content />
       </Card>
     </MdxProvider>
-  </BraidLoadableProvider>
+  </BraidProvider>
 );
 ```
+
+### ScoobieLink
+
+Render all underlying links as follows:
+
+- Internal links use client-side navigation with smooth scrolling via [react-router-hash-link],
+  and pass through the `v` URL parameter for UI version switching
+- External links open in a new tab
+
+This should be supplied to [BraidProvider] as the custom `linkComponent`:
+
+```tsx
+import { BraidProvider, TextLink } from 'braid-design-system';
+import apacTheme from 'braid-design-system/themes/apac';
+import React from 'react';
+import { ScoobieLink } from 'scoobie';
+
+export const Component = () => (
+  <BraidProvider linkComponent={ScoobieLink} theme={apacTheme}>
+    <TextLink href="/root-relative">Internal link</TextLink>
+  </BraidProvider>
+);
+```
+
+[braidprovider]: https://seek-oss.github.io/braid-design-system/components/BraidProvider
 
 ### SmartTextLink
 
 Render a text link with the same opinions as our [MdxProvider](#mdxprovider):
 
-- Internal links use client-side navigation with smooth scrolling via [react-router-hash-link],
-  and pass through the `v` URL parameter for UI version switching
 - External links open in a new tab and have an [IconNewWindow] suffix
 
 [react-router-hash-link]: https://github.com/rafrex/react-router-hash-link

--- a/README.md
+++ b/README.md
@@ -307,7 +307,8 @@ export const SomeComplexLinkElement = () => (
 ### MdxProvider
 
 Provide a base collection of [Braid]-styled renderers for child MDX documents.
-This expects with [ScoobieLink](#scoobielink).
+
+This should be paired with [ScoobieLink](#scoobielink) for proper internal link rendering.
 
 ```tsx
 import { BraidProvider, Card } from 'braid-design-system';

--- a/src/components/InternalLink.tsx
+++ b/src/components/InternalLink.tsx
@@ -1,40 +1,25 @@
 import classNames from 'classnames';
-import React, { CSSProperties, ComponentProps, ReactNode } from 'react';
+import React, { ComponentProps } from 'react';
 import { useLocation } from 'react-router-dom';
 import { NavHashLink } from 'react-router-hash-link';
 import { useStyles } from 'sku/react-treat';
 
-import { parseInternalHref } from '../private/InternalTextLink';
+import { parseInternalHref } from '../private/url';
 
 import * as styleRefs from './InternalLink.treat';
 
-interface NavLinkProps {
-  activeClassName?: Parameters<typeof classNames>[0];
-  exact?: boolean;
-  isActive?: ComponentProps<typeof NavHashLink>['isActive'];
-  onClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void;
-}
-
-interface Props extends NavLinkProps {
-  children: ReactNode;
-  className?: Parameters<typeof classNames>[0];
+interface Props
+  extends Omit<ComponentProps<typeof NavHashLink>, 'scroll' | 'smooth' | 'to'> {
   href: string;
-  title?: string;
   reset?: boolean;
-  style?: CSSProperties;
 }
 
 export const InternalLink = ({
   activeClassName,
-  children,
   className,
-  exact,
   href,
-  title,
-  isActive,
-  onClick,
   reset = true,
-  style,
+  ...restProps
 }: Props) => {
   const scroll = (element: Element) =>
     setTimeout(() => {
@@ -59,18 +44,12 @@ export const InternalLink = ({
 
   return (
     <NavHashLink
+      {...restProps}
       activeClassName={classNames(activeClassName)}
       className={mergedClassNames}
-      exact={exact}
-      isActive={isActive}
-      onClick={onClick}
       scroll={scroll}
-      title={title}
       smooth
-      style={style}
       to={to}
-    >
-      {children}
-    </NavHashLink>
+    />
   );
 };

--- a/src/components/ScoobieLink.tsx
+++ b/src/components/ScoobieLink.tsx
@@ -1,0 +1,19 @@
+import { makeLinkComponent } from 'braid-design-system';
+import React from 'react';
+
+import { isExternalHref } from '../private/url';
+
+import { InternalLink } from './InternalLink';
+
+export const ScoobieLink = makeLinkComponent(
+  ({ children, href, ...restProps }, ref) =>
+    isExternalHref(href) ? (
+      <a rel="noreferrer" target="_blank" {...restProps} href={href} ref={ref}>
+        {children}
+      </a>
+    ) : (
+      <InternalLink {...restProps} href={href} innerRef={ref}>
+        {children}
+      </InternalLink>
+    ),
+);

--- a/src/components/SmartTextLink.tsx
+++ b/src/components/SmartTextLink.tsx
@@ -1,7 +1,8 @@
+import { TextLink } from 'braid-design-system';
 import React, { ReactNode } from 'react';
 
 import { ExternalTextLink } from '../private/ExternalTextLink';
-import { InternalTextLink } from '../private/InternalTextLink';
+import { isExternalHref } from '../private/url';
 
 interface Props {
   children: ReactNode;
@@ -10,12 +11,12 @@ interface Props {
 }
 
 export const SmartTextLink = ({ children, href, title }: Props) =>
-  /^[a-z][a-z0-9+.-]*:|^\/\//i.test(href) ? (
+  isExternalHref(href) ? (
     <ExternalTextLink href={href} title={title}>
       {children}
     </ExternalTextLink>
   ) : (
-    <InternalTextLink href={href} title={title}>
+    <TextLink href={href} title={title}>
       {children}
-    </InternalTextLink>
+    </TextLink>
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export { CodeBlock } from './components/CodeBlock';
 export { InlineCode } from './components/InlineCode';
 export { InternalLink } from './components/InternalLink';
 export { MdxProvider } from './components/MdxProvider';
+export { ScoobieLink } from './components/ScoobieLink';
 export { SmartTextLink } from './components/SmartTextLink';
 export { Table } from './components/Table';
 export { TableRow } from './components/TableRow';

--- a/src/private/url.test.ts
+++ b/src/private/url.test.ts
@@ -1,4 +1,26 @@
-import { parseInternalHref } from './InternalTextLink';
+import { isExternalHref, parseInternalHref } from './url';
+
+describe('isExternalHref', () => {
+  test.each`
+    href                     | expected
+    ${'ftp://example.com'}   | ${true}
+    ${'http://example.com'}  | ${true}
+    ${'https://example.com'} | ${true}
+    ${'//example.com'}       | ${true}
+    ${'/'}                   | ${false}
+    ${'example.com'}         | ${false}
+    ${'.'}                   | ${false}
+    ${'..'}                  | ${false}
+    ${'example.com/'}        | ${false}
+    ${'./'}                  | ${false}
+    ${'../'}                 | ${false}
+    ${'/path'}               | ${false}
+    ${'/.'}                  | ${false}
+    ${'/..'}                 | ${false}
+  `('$href', ({ href, expected }) =>
+    expect(isExternalHref(href)).toBe(expected),
+  );
+});
 
 describe('parseInternalHref', () => {
   it('preferences the v URL parameter from location', () => {

--- a/src/private/url.ts
+++ b/src/private/url.ts
@@ -1,10 +1,5 @@
 import url from 'url';
 
-import { TextLinkRenderer } from 'braid-design-system';
-import React, { ReactNode } from 'react';
-
-import { InternalLink } from '../components/InternalLink';
-
 const URL = url.URL ?? window.URL;
 const URLSearchParams = url.URLSearchParams ?? window.URLSearchParams;
 
@@ -52,18 +47,5 @@ export const parseInternalHref = (
   };
 };
 
-interface Props {
-  children: ReactNode;
-  href: string;
-  title?: string;
-}
-
-export const InternalTextLink = ({ children, href, title }: Props) => (
-  <TextLinkRenderer>
-    {(rendererProps) => (
-      <InternalLink {...rendererProps} href={href} title={title} reset={false}>
-        {children}
-      </InternalLink>
-    )}
-  </TextLinkRenderer>
-);
+export const isExternalHref = (href: string) =>
+  /^[a-z][a-z0-9+.-]*:|^\/\//i.test(href);

--- a/src/stories/decorator.tsx
+++ b/src/stories/decorator.tsx
@@ -5,7 +5,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { select, text } from 'sku/@storybook/addon-knobs';
 import { addDecorator } from 'sku/@storybook/react';
 
-import { MdxProvider } from '..';
+import { MdxProvider, ScoobieLink } from '..';
 import { robotoHref, robotoMonoHref } from '../../typography';
 import { DEFAULT_SIZE, SIZES } from '../private/size';
 
@@ -13,6 +13,7 @@ type DecoratorFunction = Parameters<typeof addDecorator>[0];
 
 export const withBraid: DecoratorFunction = (story) => (
   <BraidLoadableProvider
+    linkComponent={ScoobieLink}
     themeName={select(
       'BraidLoadableProvider.themeName',
       [


### PR DESCRIPTION
Braid has deprecated custom `LinkRenderer` components in favour of the `linkComponent` prop on `BraidProvider`. It's about time we get on board with this change, as it allows us to customise rendering across all link components, including `ButtonLink`s.

BREAKING CHANGE: `MdxProvider` and `SmartTextLink` no longer customise the rendering of internal links by themselves. Supply `ScoobieLink` to `BraidProvider` to restore this behaviour.

```diff
import { BraidProvider } from 'braid-design-system';
import apacTheme from 'braid-design-system/themes/apac';
+ import { ScoobieLink } from 'scoobie';

export const App = () => (
-   <BraidProvider theme={apacTheme}>
+   <BraidProvider linkComponent={ScoobieLink} theme={apacTheme}>
    ...
  </BraidProvider>
);
```