### PR TITLE
fix(ScoobieLink): Disable internal link reset

### DIFF
--- a/src/components/ScoobieLink.tsx
+++ b/src/components/ScoobieLink.tsx
@@ -12,7 +12,7 @@ export const ScoobieLink = makeLinkComponent(
         {children}
       </a>
     ) : (
-      <InternalLink {...restProps} href={href} innerRef={ref}>
+      <InternalLink {...restProps} href={href} innerRef={ref} reset={false}>
         {children}
       </InternalLink>
     ),


### PR DESCRIPTION
The reset messes with `:visited` styling as an internal Braid link renderer.