### PR TITLE
fix(CodeBlock): Trim Firefox line spacing

### DIFF
--- a/src/components/CodeBlock/LineNumbers.tsx
+++ b/src/components/CodeBlock/LineNumbers.tsx
@@ -20,8 +20,8 @@ export const LineNumbers = ({ count, codeSize }: Props) => {
     <Box aria-hidden className={styles.lineNumberContainer} padding="medium">
       <Stack align="right" space="small">
         {numbers.map((number) => (
-          <Box className={styles.code[codeSize]} component="pre" key={number}>
-            {number}
+          <Box className={styles.code[codeSize]} key={number}>
+            <Box component="pre">{number}</Box>
           </Box>
         ))}
       </Stack>

--- a/src/components/CodeBlock/Lines.tsx
+++ b/src/components/CodeBlock/Lines.tsx
@@ -22,16 +22,14 @@ export const Lines = ({ codeSize, getTokenProps, lines }: Props) => {
     <Box padding="medium">
       <Stack space="small">
         {lines.map((line, lineIndex) => (
-          <Box
-            className={styles.code[codeSize]}
-            component="pre"
-            key={lineIndex}
-          >
-            {line.map((token, tokenIndex) => {
-              const props = getTokenProps({ token });
+          <Box className={styles.code[codeSize]} key={lineIndex}>
+            <Box component="pre">
+              {line.map((token, tokenIndex) => {
+                const props = getTokenProps({ token });
 
-              return <Box component="span" {...props} key={tokenIndex} />;
-            })}
+                return <Box component="span" {...props} key={tokenIndex} />;
+              })}
+            </Box>
           </Box>
         ))}
       </Stack>


### PR DESCRIPTION
Firefox 87+, Capsize 2 and `pre` whitespacing don't seem to get along with each other. This fixes the issue at the cost of an extra node per line, and I've checked that it hasn't regressed in Chrome or Safari.