### PR TITLE
fix(CodeBlock): Lock prism-react-renderer version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "classnames": "^2.2.6",
     "find-up": "^5.0.0",
     "polished": "^4.0.0",
-    "prism-react-renderer": "^1.1.1",
+    "prism-react-renderer": "1.1.1",
     "react-keyed-flatten-children": "^1.3.0",
     "react-router-hash-link": "^2.0.0",
     "refractor": "^3.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14049,7 +14049,7 @@ pretty-ms@^7.0.1:
   dependencies:
     parse-ms "^2.1.0"
 
-prism-react-renderer@^1.1.1:
+prism-react-renderer@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/prism-react-renderer/-/prism-react-renderer-1.1.1.tgz#1c1be61b1eb9446a146ca7a50b7bcf36f2a70a44"
   integrity sha512-MgMhSdHuHymNRqD6KM3eGS0PNqgK9q4QF5P0yoQQvpB6jNjeSAi3jcSAz0Sua/t9fa4xDOMar9HJbLa08gl9ug==


### PR DESCRIPTION
I noticed that our Developer Site syntax highlighting has regressed:

1. GraphQL variables are a pale blue with poor contrast
2. JSON comments (that we use in JSONC blocks) are highlighted as errors

These changes were made in v1.2.0, so we can restore our expected highlighting by locking v1.1.1 in. We probably need to upstream changes before we can land future versions; the first point requires a fix to
the prism-react-renderer GitHub theme and the second point requires us to contribute a new JSONC language definition to prism that is distinct from the base JSON language definition.