### PR TITLE
Try to disable `@storybook/addons` majors

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,3 +1,12 @@
 {
   extends: ['github>seek-oss/rynovate'],
+  packageRules: [
+    {
+      // We need to match the Storybook version bundled in sku.
+      matchPackageNames: ['@storybook/addons'],
+      matchManagers: ['npm'],
+      matchUpdateTypes: ['major'],
+      enabled: false,
+    },
+  ],
 }


### PR DESCRIPTION
We depend on matching sku's internal Storybook version, which is still stuck at v5 for now. If this doesn't work due to grouping shenanigans, I'll have to copy+paste the whole config.