### PR TITLE
fix(InlineCode): Show hex colour previews

### DIFF
--- a/src/components/InlineCode.css.ts
+++ b/src/components/InlineCode.css.ts
@@ -1,4 +1,5 @@
-import { style } from '@vanilla-extract/css';
+import { style, styleVariants } from '@vanilla-extract/css';
+import { calc } from '@vanilla-extract/css-utils';
 import { vars } from 'braid-design-system/css';
 import { darken } from 'polished';
 
@@ -11,16 +12,31 @@ export const base = style({
   lineHeight: 'normal',
 });
 
-export const weight = {
-  regular: style({
-    backgroundColor: codeBackgroundColor,
+export const colourBlock = style({
+  minWidth: calc.multiply(vars.grid, 5),
+});
+
+export const colourBlockWrapper = style({
+  userSelect: 'none',
+  whiteSpace: 'pre-wrap',
+});
+
+export const weightBorder = styleVariants({
+  regular: {
     borderColor: darken(0.05, codeBackgroundColor),
     borderStyle: 'solid',
     borderWidth: vars.borderWidth.standard,
+  },
 
+  weak: {},
+});
+
+export const weight = styleVariants({
+  regular: {
+    backgroundColor: codeBackgroundColor,
     paddingLeft: vars.space.xxsmall,
     paddingRight: vars.space.xxsmall,
-  }),
+  },
 
-  weak: style({}),
-};
+  weak: {},
+});

--- a/src/components/InlineCode.tsx
+++ b/src/components/InlineCode.tsx
@@ -1,7 +1,10 @@
 import { Box } from 'braid-design-system';
-import React, { ReactNode } from 'react';
+import React, { Fragment, ReactNode } from 'react';
 
 import * as styles from './InlineCode.css';
+
+const isHexColour = (value: unknown): value is string =>
+  typeof value === 'string' && /^#[0-9a-f]{6}$/i.test(value);
 
 interface Props {
   children: ReactNode;
@@ -9,11 +12,36 @@ interface Props {
 }
 
 export const InlineCode = ({ children, weight = 'regular' }: Props) => (
-  <Box
-    borderRadius="standard"
-    className={[styles.base, styles.weight[weight]]}
-    component="code"
-  >
-    {children}
-  </Box>
+  <Fragment>
+    {isHexColour(children) ? (
+      <Box component="span" className={styles.colourBlockWrapper}>
+        <Box
+          borderRadius="standard"
+          className={[
+            styles.base,
+            styles.colourBlock,
+            styles.weightBorder[weight],
+          ]}
+          component="span"
+          display="inlineBlock"
+          height="full"
+          style={{ backgroundColor: children }}
+        >
+          {' '}
+        </Box>{' '}
+      </Box>
+    ) : undefined}
+
+    <Box
+      borderRadius="standard"
+      className={[
+        styles.base,
+        styles.weight[weight],
+        styles.weightBorder[weight],
+      ]}
+      component="code"
+    >
+      {children}
+    </Box>
+  </Fragment>
 );


### PR DESCRIPTION
This is some fairly jank code to get `InlineCode` to automatically detect when its contents are a hex colour code and display a preceding preview.

![Kapture 2021-07-21 at 16 29 07](https://user-images.githubusercontent.com/25572311/126441904-d5198cbe-eb16-4901-8a15-434d12057148.gif)
