### PR TITLE
fix(mermaid): Improve edge label alignment

### DIFF
--- a/remark/mermaid/style.css
+++ b/remark/mermaid/style.css
@@ -54,6 +54,7 @@ g.cluster rect {
 }
 
 g.cluster div,
+g.edgeLabel foreignObject,
 g.edgeLabel span.edgeLabel,
 g.label div,
 g.node div,


### PR DESCRIPTION
I noticed that the edge labels on our flowcharts are drooping and getting cut off:

https://developer.seek.com/static/311adde78c8acf676510c8b8ae84f47a.svg