### PR TITLE
feat(ScoobieLink): Render download links as anchors

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,8 +392,8 @@ Render all underlying links as follows:
   and pass through the `v` URL parameter for UI version switching
 - External links open in a new tab
 - Download links prompt user to download attachments.
-  Link components must set `download` attribute to set file name.
-  If no value is provided, default file name will be given.
+  Link components must set `download` attribute with suggested file name value.
+  If no value is provided, a default file name will be given.
 
 This should be supplied to [BraidProvider] as the custom `linkComponent`:
 

--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ Render all underlying links as follows:
   and pass through the `v` URL parameter for UI version switching
 - External links open in a new tab
 - Download links prompt user to download attachments.
-  Link components must set `download` attribute with suggested file name value.
+  Link components must set `download` attribute and a suggested file name value may be provided.
   If no value is provided, a default file name will be given.
 
 This should be supplied to [BraidProvider] as the custom `linkComponent`:

--- a/README.md
+++ b/README.md
@@ -391,6 +391,8 @@ Render all underlying links as follows:
 - Internal links use client-side navigation with smooth scrolling via [react-router-hash-link],
   and pass through the `v` URL parameter for UI version switching
 - External links open in a new tab
+- Attachment links open attachments in a new tab.
+  Link components must set `datatype` attribute to `attachments`
 
 This should be supplied to [BraidProvider] as the custom `linkComponent`:
 

--- a/README.md
+++ b/README.md
@@ -391,9 +391,9 @@ Render all underlying links as follows:
 - Internal links use client-side navigation with smooth scrolling via [react-router-hash-link],
   and pass through the `v` URL parameter for UI version switching
 - External links open in a new tab
-- Download links prompt user to download attachments.
-  Link components must set `download` attribute and a suggested file name value may be provided.
-  If no value is provided, a default file name will be given.
+- Links with a [`download` attribute] prompt the user with a file download
+
+[`download` attribute]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-download
 
 This should be supplied to [BraidProvider] as the custom `linkComponent`:
 

--- a/README.md
+++ b/README.md
@@ -391,8 +391,9 @@ Render all underlying links as follows:
 - Internal links use client-side navigation with smooth scrolling via [react-router-hash-link],
   and pass through the `v` URL parameter for UI version switching
 - External links open in a new tab
-- Attachment links open attachments in a new tab.
-  Link components must set `datatype` attribute to `attachments`
+- Download links prompt user to download attachments.
+  Link components must set `download` attribute to set file name.
+  If no value is provided, default file name will be given.
 
 This should be supplied to [BraidProvider] as the custom `linkComponent`:
 

--- a/src/components/ScoobieLink.tsx
+++ b/src/components/ScoobieLink.tsx
@@ -13,6 +13,7 @@ export const ScoobieLink = makeLinkComponent(
           rel="noreferrer"
           target="_blank"
           {...restProps}
+          download={download}
           href={href}
           ref={ref}
         >

--- a/src/components/ScoobieLink.tsx
+++ b/src/components/ScoobieLink.tsx
@@ -15,6 +15,7 @@ export const ScoobieLink = makeLinkComponent(
           {...restProps}
           href={href}
           ref={ref}
+          download={download}
         >
           {children}
         </a>

--- a/src/components/ScoobieLink.tsx
+++ b/src/components/ScoobieLink.tsx
@@ -6,8 +6,8 @@ import { isExternalHref } from '../private/url';
 import { InternalLink } from './InternalLink';
 
 export const ScoobieLink = makeLinkComponent(
-  ({ children, href, datatype, ...restProps }, ref) => {
-    if (isExternalHref(href) || datatype === 'attachments') {
+  ({ children, href, download, ...restProps }, ref) => {
+    if (isExternalHref(href) || download) {
       return (
         <a
           rel="noreferrer"
@@ -22,13 +22,7 @@ export const ScoobieLink = makeLinkComponent(
     }
 
     return (
-      <InternalLink
-        {...restProps}
-        href={href}
-        innerRef={ref}
-        reset={false}
-        datatype={datatype}
-      >
+      <InternalLink {...restProps} href={href} innerRef={ref} reset={false}>
         {children}
       </InternalLink>
     );

--- a/src/components/ScoobieLink.tsx
+++ b/src/components/ScoobieLink.tsx
@@ -6,14 +6,31 @@ import { isExternalHref } from '../private/url';
 import { InternalLink } from './InternalLink';
 
 export const ScoobieLink = makeLinkComponent(
-  ({ children, href, ...restProps }, ref) =>
-    isExternalHref(href) ? (
-      <a rel="noreferrer" target="_blank" {...restProps} href={href} ref={ref}>
-        {children}
-      </a>
-    ) : (
-      <InternalLink {...restProps} href={href} innerRef={ref} reset={false}>
+  ({ children, href, datatype, ...restProps }, ref) => {
+    if (isExternalHref(href) || datatype === 'attachments') {
+      return (
+        <a
+          rel="noreferrer"
+          target="_blank"
+          {...restProps}
+          href={href}
+          ref={ref}
+        >
+          {children}
+        </a>
+      );
+    }
+
+    return (
+      <InternalLink
+        {...restProps}
+        href={href}
+        innerRef={ref}
+        reset={false}
+        datatype={datatype}
+      >
         {children}
       </InternalLink>
-    ),
+    );
+  },
 );

--- a/src/components/ScoobieLink.tsx
+++ b/src/components/ScoobieLink.tsx
@@ -7,7 +7,7 @@ import { InternalLink } from './InternalLink';
 
 export const ScoobieLink = makeLinkComponent(
   ({ children, href, download, ...restProps }, ref) => {
-    if (isExternalHref(href) || download) {
+    if (isExternalHref(href)) {
       return (
         <a
           rel="noreferrer"
@@ -15,8 +15,15 @@ export const ScoobieLink = makeLinkComponent(
           {...restProps}
           href={href}
           ref={ref}
-          download={download}
         >
+          {children}
+        </a>
+      );
+    }
+
+    if (download) {
+      return (
+        <a {...restProps} href={href} ref={ref} download={download}>
           {children}
         </a>
       );

--- a/src/components/ScoobieLink.tsx
+++ b/src/components/ScoobieLink.tsx
@@ -7,7 +7,7 @@ import { InternalLink } from './InternalLink';
 
 export const ScoobieLink = makeLinkComponent(
   ({ children, href, download, ...restProps }, ref) => {
-    if (isExternalHref(href) || download) {
+    if (isExternalHref(href)) {
       return (
         <a
           rel="noreferrer"
@@ -16,6 +16,14 @@ export const ScoobieLink = makeLinkComponent(
           href={href}
           ref={ref}
         >
+          {children}
+        </a>
+      );
+    }
+
+    if (download) {
+      return (
+        <a rel="noreferrer" {...restProps} href={href} ref={ref}>
           {children}
         </a>
       );

--- a/src/components/ScoobieLink.tsx
+++ b/src/components/ScoobieLink.tsx
@@ -7,7 +7,7 @@ import { InternalLink } from './InternalLink';
 
 export const ScoobieLink = makeLinkComponent(
   ({ children, href, download, ...restProps }, ref) => {
-    if (isExternalHref(href)) {
+    if (isExternalHref(href) || download) {
       return (
         <a
           rel="noreferrer"
@@ -16,14 +16,6 @@ export const ScoobieLink = makeLinkComponent(
           href={href}
           ref={ref}
         >
-          {children}
-        </a>
-      );
-    }
-
-    if (download) {
-      return (
-        <a rel="noreferrer" {...restProps} href={href} ref={ref}>
           {children}
         </a>
       );


### PR DESCRIPTION
This adds a third case to custom links behaviour. 

Previously we account for internal and external links based on `href` attribute. Here we use `download` attribute to determine if the link is for download and not to be navigated to (no client side rendering happens)