### PR TITLE
Split out MdxDecorator

### DIFF
--- a/src/components/Blockquote.stories.tsx
+++ b/src/components/Blockquote.stories.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { ComponentProps } from 'react';
 
 import { argTypes } from '../storybook/controls';
-import { ScoobieDecorator } from '../storybook/decorator';
+import { DesignDecorator } from '../storybook/decorators';
 
 import { Blockquote } from './Blockquote';
 
@@ -15,7 +15,7 @@ export default {
     size: argTypes.size,
   },
   component: Blockquote,
-  decorators: [ScoobieDecorator],
+  decorators: [DesignDecorator],
   title: 'Blockquote',
 };
 

--- a/src/components/CodeBlock.stories.tsx
+++ b/src/components/CodeBlock.stories.tsx
@@ -4,7 +4,7 @@ import 'loki/configure-react';
 import React, { ComponentProps } from 'react';
 
 import { argTypes } from '../storybook/controls';
-import { ScoobieDecorator } from '../storybook/decorator';
+import { DesignDecorator } from '../storybook/decorators';
 
 import { CodeBlock } from './CodeBlock';
 
@@ -22,7 +22,7 @@ export default {
     },
   },
   component: CodeBlock,
-  decorators: [ScoobieDecorator],
+  decorators: [DesignDecorator],
   title: 'CodeBlock',
 };
 

--- a/src/components/CopyableText.stories.tsx
+++ b/src/components/CopyableText.stories.tsx
@@ -4,7 +4,7 @@ import 'loki/configure-react';
 import React from 'react';
 import { ComponentProps } from 'react';
 
-import { ScoobieDecorator } from '../storybook/decorator';
+import { DesignDecorator } from '../storybook/decorators';
 
 import { CopyableText } from './CopyableText';
 
@@ -27,7 +27,7 @@ export default {
     },
   },
   component: CopyableText,
-  decorators: [ScoobieDecorator],
+  decorators: [DesignDecorator],
   title: 'CopyableText',
 };
 

--- a/src/components/InlineCode.stories.tsx
+++ b/src/components/InlineCode.stories.tsx
@@ -5,7 +5,7 @@ import { Text } from 'braid-design-system';
 import React from 'react';
 import { ComponentProps } from 'react';
 
-import { ScoobieDecorator } from '../storybook/decorator';
+import { DesignDecorator } from '../storybook/decorators';
 
 import { InlineCode } from './InlineCode';
 
@@ -20,7 +20,7 @@ export default {
     },
   },
   component: InlineCode,
-  decorators: [ScoobieDecorator],
+  decorators: [DesignDecorator],
   title: 'InlineCode',
 };
 

--- a/src/components/InternalLink.stories.tsx
+++ b/src/components/InternalLink.stories.tsx
@@ -5,7 +5,7 @@ import { Alert, Stack, Text } from 'braid-design-system';
 import React from 'react';
 import { ComponentProps } from 'react';
 
-import { ScoobieDecorator } from '../storybook/decorator';
+import { DesignDecorator } from '../storybook/decorators';
 
 import { InternalLink } from './InternalLink';
 
@@ -19,7 +19,7 @@ export default {
     },
   },
   component: InternalLink,
-  decorators: [ScoobieDecorator],
+  decorators: [DesignDecorator],
   title: 'InternalLink',
 };
 

--- a/src/components/MdxProvider.stories.tsx
+++ b/src/components/MdxProvider.stories.tsx
@@ -3,7 +3,7 @@ import 'loki/configure-react';
 
 import React from 'react';
 
-import { ScoobieDecorator } from '../storybook/decorator';
+import { DesignDecorator, MdxDecorator } from '../storybook/decorators';
 import BlockquoteMarkdown from '../storybook/markdown/blockquote.mdx';
 import CodeMarkdown from '../storybook/markdown/code.mdx';
 import CombinationMarkdown from '../storybook/markdown/combination.mdx';
@@ -18,7 +18,7 @@ import { MdxProvider } from './MdxProvider';
 
 export default {
   component: MdxProvider,
-  decorators: [ScoobieDecorator],
+  decorators: [DesignDecorator, MdxDecorator],
   parameters: {
     controls: { hideNoControlsWarning: true },
   },

--- a/src/components/SmartTextLink.stories.tsx
+++ b/src/components/SmartTextLink.stories.tsx
@@ -4,7 +4,7 @@ import 'loki/configure-react';
 import { Text } from 'braid-design-system';
 import React, { ComponentProps } from 'react';
 
-import { ScoobieDecorator } from '../storybook/decorator';
+import { DesignDecorator } from '../storybook/decorators';
 
 import { SmartTextLink } from './SmartTextLink';
 
@@ -19,7 +19,7 @@ export default {
     },
   },
   component: SmartTextLink,
-  decorators: [ScoobieDecorator],
+  decorators: [DesignDecorator],
   title: 'SmartTextLink',
 };
 

--- a/src/components/Table.stories.tsx
+++ b/src/components/Table.stories.tsx
@@ -5,7 +5,7 @@ import { Text } from 'braid-design-system';
 import React, { ComponentProps, Fragment } from 'react';
 
 import { argTypes } from '../storybook/controls';
-import { ScoobieDecorator } from '../storybook/decorator';
+import { DesignDecorator } from '../storybook/decorators';
 
 import { Table } from './Table';
 import { TableRow } from './TableRow';
@@ -22,7 +22,7 @@ export default {
     },
   },
   component: Table,
-  decorators: [ScoobieDecorator],
+  decorators: [DesignDecorator],
   title: 'Table',
 };
 

--- a/src/components/TocRenderer.stories.tsx
+++ b/src/components/TocRenderer.stories.tsx
@@ -4,7 +4,7 @@ import 'loki/configure-react';
 import { Stack, Text } from 'braid-design-system';
 import React from 'react';
 
-import { ScoobieDecorator } from '../storybook/decorator';
+import { DesignDecorator } from '../storybook/decorators';
 import Headings from '../storybook/markdown/headings.mdx';
 
 import { SmartTextLink } from './SmartTextLink';
@@ -12,7 +12,7 @@ import { TocRenderer } from './TocRenderer';
 
 export default {
   component: TocRenderer,
-  decorators: [ScoobieDecorator],
+  decorators: [DesignDecorator],
   parameters: {
     controls: { hideNoControlsWarning: true },
   },

--- a/src/components/WrapperRenderer.stories.tsx
+++ b/src/components/WrapperRenderer.stories.tsx
@@ -4,14 +4,14 @@ import 'loki/configure-react';
 import { Text } from 'braid-design-system';
 import React, { Children } from 'react';
 
-import { ScoobieDecorator } from '../storybook/decorator';
+import { DesignDecorator } from '../storybook/decorators';
 import Wrapper from '../storybook/markdown/wrapper.mdx';
 
 import { WrapperRenderer } from './WrapperRenderer';
 
 export default {
   component: WrapperRenderer,
-  decorators: [ScoobieDecorator],
+  decorators: [DesignDecorator],
   parameters: {
     controls: { hideNoControlsWarning: true },
   },

--- a/src/storybook/decorators.tsx
+++ b/src/storybook/decorators.tsx
@@ -14,11 +14,11 @@ import { MdxProvider, ScoobieLink } from '..';
 import { robotoHref, robotoMonoHref } from '../../typography';
 import { DEFAULT_SIZE, SIZES } from '../private/size';
 
-interface Props {
+interface ProviderProps {
   children: ReactNode;
 }
 
-const BraidStorybookProvider = ({ children }: Props) => (
+const BraidStorybookProvider = ({ children }: ProviderProps) => (
   <BraidLoadableProvider
     linkComponent={ScoobieLink}
     themeName={select(
@@ -41,7 +41,24 @@ const BraidStorybookProvider = ({ children }: Props) => (
   </BraidLoadableProvider>
 );
 
-const MdxStorybookProvider = ({ children }: Props) => (
+type DecoratorFn = Parameters<typeof addDecorator>[0];
+
+export const DesignDecorator: DecoratorFn = (story) => (
+  <BrowserRouter>
+    <Helmet>
+      <link href={robotoHref} rel="stylesheet" />
+      <link href={robotoMonoHref} rel="stylesheet" />
+    </Helmet>
+
+    <BraidStorybookProvider>
+      <ContentBlock>
+        <Card>{story()}</Card>
+      </ContentBlock>
+    </BraidStorybookProvider>
+  </BrowserRouter>
+);
+
+export const MdxDecorator: DecoratorFn = (story) => (
   <MdxProvider
     graphqlPlayground={
       text(
@@ -51,25 +68,6 @@ const MdxStorybookProvider = ({ children }: Props) => (
     }
     size={select('MdxProvider.size', SIZES, DEFAULT_SIZE)}
   >
-    {children}
+    {story()}
   </MdxProvider>
-);
-
-type DecoratorFunction = Parameters<typeof addDecorator>[0];
-
-export const ScoobieDecorator: DecoratorFunction = (story) => (
-  <BrowserRouter>
-    <Helmet>
-      <link href={robotoHref} rel="stylesheet" />
-      <link href={robotoMonoHref} rel="stylesheet" />
-    </Helmet>
-
-    <BraidStorybookProvider>
-      <MdxStorybookProvider>
-        <ContentBlock>
-          <Card>{story()}</Card>
-        </ContentBlock>
-      </MdxStorybookProvider>
-    </BraidStorybookProvider>
-  </BrowserRouter>
 );


### PR DESCRIPTION
This should remove the MdxProvider knobs from standalone component
stories, where they are ineffectual.