### PR TITLE
fix(deps): Pin file-loader 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@vanilla-extract/css-utils": "^0.1.1",
     "capsize": "^2.0.0",
     "clsx": "^1.1.1",
+    "file-loader": "^6.2.0",
     "find-up": "^5.0.0",
     "fs-extra": "^10.0.0",
     "polished": "^4.0.0",

--- a/remark/imageToJsx.js
+++ b/remark/imageToJsx.js
@@ -129,7 +129,7 @@ const inferImageSrc = (processModulePath, url) => {
     return `"${encodeURI(url)}"`;
   }
 
-  // Resolve default export for other images
+  // Resolve default ESM export
   return `require('${processModulePath(url)}').default`;
 };
 

--- a/remark/imageToJsx.js
+++ b/remark/imageToJsx.js
@@ -11,12 +11,6 @@ const TITLE_DIRECTIVE = /^=([0-9]*)x([0-9]*)$/;
  */
 const cleanseDoubleQuotes = (str) => str.replace(/"/g, "''");
 
-/**
- *
- * @param {string} url
- */
-const isSvgUrl = (url) => url.toLocaleLowerCase().endsWith('.svg');
-
 let $repoRoot;
 /**
  * @returns {string}
@@ -133,11 +127,6 @@ const inferImageSrc = (processModulePath, url) => {
   // Use directly
   if (url.startsWith('https://')) {
     return `"${encodeURI(url)}"`;
-  }
-
-  // Resolve direct export for SVGs
-  if (isSvgUrl(url)) {
-    return `require('${processModulePath(url)}')`;
   }
 
   // Resolve default export for other images

--- a/remark/imageToJsx.test.ts
+++ b/remark/imageToJsx.test.ts
@@ -293,7 +293,7 @@ describe('imageToJsx', () => {
           "value": "<img
           alt=\\"\\"
           data-scoobie-style=\\"default\\"
-          src={require('./drawing.svg')}
+          src={require('./drawing.svg').default}
           title=\\"\\"
         />",
         }
@@ -314,7 +314,7 @@ describe('imageToJsx', () => {
           "value": "<img
           alt=\\"\\"
           data-scoobie-style=\\"default\\"
-          src={require('./drawing.svg')}
+          src={require('./drawing.svg').default}
           title=\\"\\"
         />",
         }
@@ -335,7 +335,7 @@ describe('imageToJsx', () => {
           "value": "<img
           alt=\\"\\"
           data-scoobie-style=\\"default\\"
-          src={require('../src/assets/drawing.svg')}
+          src={require('../src/assets/drawing.svg').default}
           title=\\"\\"
         />",
         }
@@ -358,7 +358,7 @@ describe('imageToJsx', () => {
           "value": "<img
           alt=\\"bravo\\"
           data-scoobie-style=\\"default\\"
-          src={require('./drawing.svg')}
+          src={require('./drawing.svg').default}
           title=\\"alpha\\"
         />",
         }
@@ -380,7 +380,7 @@ describe('imageToJsx', () => {
           "value": "<img
           alt=\\"bravo\\"
           data-scoobie-style=\\"default\\"
-          src={require('./drawing.svg')}
+          src={require('./drawing.svg').default}
           title=\\"\\"
         />",
         }
@@ -423,7 +423,7 @@ describe('imageToJsx', () => {
           "value": "<img
           alt=\\"\\"
           data-scoobie-style=\\"default\\"
-          src={require('./drawing.svg')}
+          src={require('./drawing.svg').default}
           style={{ height: 50, maxWidth: '100%', width: 100 }}
           title=\\"Alpha\\"
         />",
@@ -446,7 +446,7 @@ describe('imageToJsx', () => {
           "value": "<img
           alt=\\"\\"
           data-scoobie-style=\\"none\\"
-          src={require('./drawing.svg')}
+          src={require('./drawing.svg').default}
           title=\\"Alpha\\"
         />",
         }

--- a/webpack/webpackPlugin.js
+++ b/webpack/webpackPlugin.js
@@ -3,7 +3,7 @@ const { remarkPlugin } = require('../remark');
 /**
  * Vendored from `sku/config/webpack/utils`.
  *
- * {@link https://github.com/seek-oss/sku/blob/v10.12.0/config/webpack/utils/index.js#L10-L11}
+ * {@link https://github.com/seek-oss/sku/blob/v11.0.1/config/webpack/utils/index.js#L10-L11}
  */
 const SKU_WEBPACK_UTILS = {
   SVG: /\.svg$/,


### PR DESCRIPTION
It seems we were lucking out by resolving a 4.x version of `file-loader` previously. Newer versions default to ESM and allow us to unify our code paths.

https://github.com/webpack-contrib/file-loader/blob/master/CHANGELOG.md#500-2019-11-22