### PR TITLE
Use Node.js 14 on release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,10 @@ jobs:
           fetch-depth: 0
           lfs: true
 
-      - name: Set up Node.js 12.x
+      - name: Set up Node.js 14.x
         uses: actions/setup-node@master
         with:
-          node-version: 12.x
+          node-version: 14.x
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile --ignore-optional --non-interactive


### PR DESCRIPTION
This has been failing because semantic-release now requires Node.js 14.