### PR TITLE
fix(InternalLink): Fix React Router v5 typing

### DIFF
--- a/src/components/InternalLink.tsx
+++ b/src/components/InternalLink.tsx
@@ -38,7 +38,10 @@ export const InternalLink = forwardRef<HTMLAnchorElement, Props>(
         className={(prop) => {
           // The boolean prop was introduced in React Router v5.3 as a bridge to
           // v6, then v6 decided to break the function signature anyway 🙃.
-          const isActive = typeof prop === 'boolean' ? prop : prop.isActive;
+          const isActive =
+            typeof prop === 'boolean'
+              ? prop
+              : (prop as { isActive: boolean }).isActive;
 
           return clsx(
             reset ? styles.reset : null,


### PR DESCRIPTION
With React Router v5 types, this was complaining that the `isActive` prop does not exist in the `never` else case.