### PR TITLE
feat(CopyableText): Use text icon slots

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@storybook/storybook-deployer": "2.8.12",
     "@types/react": "18.0.17",
     "@types/react-dom": "18.0.6",
-    "braid-design-system": "31.20.0",
+    "braid-design-system": "31.21.0",
     "loki": "0.30.3",
     "react": "18.2.0",
     "react-dom": "18.2.0",
@@ -56,7 +56,7 @@
   ],
   "peerDependencies": {
     "@mermaid-js/mermaid-cli": ">= 8.13.7 < 10",
-    "braid-design-system": ">= 31.14.0",
+    "braid-design-system": ">= 31.21.0",
     "react": ">= 17 < 19",
     "react-router-dom": ">= 5.3.0",
     "sku": ">= 10.13.4 < 12"

--- a/src/components/CodeBlock/GraphQLPlaygroundAction.tsx
+++ b/src/components/CodeBlock/GraphQLPlaygroundAction.tsx
@@ -29,8 +29,13 @@ export const GraphQLPlaygroundAction = ({
 
   return (
     <Text size={smallerSize} weight="medium">
-      <TextLink href={href} rel="noreferrer" target="_blank">
-        <IconVideo alignY="lowercase" /> GraphQL Explorer
+      <TextLink
+        href={href}
+        icon={<IconVideo alignY="lowercase" />}
+        rel="noreferrer"
+        target="_blank"
+      >
+        GraphQL Explorer
       </TextLink>
     </Text>
   );

--- a/src/components/CopyableText.stories.tsx
+++ b/src/components/CopyableText.stories.tsx
@@ -13,17 +13,29 @@ export default {
   args: {
     braidThemeName: defaultArgs.braidThemeName,
     children: 'copy me',
+    copiedIcon: 'undefined',
     copiedLabel: 'undefined',
+    copyIcon: 'undefined',
     copyLabel: 'undefined',
     size: 'standard',
   },
   argTypes: {
     braidThemeName: defaultArgTypes.braidThemeName,
     children: { control: { type: 'text' } },
+    copiedIcon: {
+      control: { type: 'radio' },
+      mapping: { undefined, false: false },
+      options: ['undefined', 'false'],
+    },
     copiedLabel: {
       control: { type: 'radio' },
       mapping: { undefined, custom: 'Custom copied label' },
       options: ['undefined', 'custom'],
+    },
+    copyIcon: {
+      control: { type: 'radio' },
+      mapping: { undefined, false: false },
+      options: ['undefined', 'false'],
     },
     copyLabel: {
       control: { type: 'radio' },

--- a/src/components/CopyableText.tsx
+++ b/src/components/CopyableText.tsx
@@ -1,35 +1,21 @@
 import { IconCopy, IconTick, Text, TextLinkButton } from 'braid-design-system';
-import React, {
-  ComponentProps,
-  Fragment,
-  ReactNode,
-  useCallback,
-  useState,
-} from 'react';
-
-const DefaultCopiedLabel = () => (
-  <Fragment>
-    <IconTick alignY="lowercase" /> Copied
-  </Fragment>
-);
-
-const DefaultCopyLabel = () => (
-  <Fragment>
-    <IconCopy alignY="lowercase" /> Copy
-  </Fragment>
-);
+import React, { ComponentProps, ReactNode, useCallback, useState } from 'react';
 
 interface Props {
   children: string;
+  copiedIcon?: ComponentProps<typeof Text>['icon'] | false;
   copiedLabel?: ReactNode;
+  copyIcon?: ComponentProps<typeof TextLinkButton>['icon'] | false;
   copyLabel?: ReactNode;
   size?: ComponentProps<typeof Text>['size'];
 }
 
 export const CopyableText = ({
   children,
-  copiedLabel = <DefaultCopiedLabel />,
-  copyLabel = <DefaultCopyLabel />,
+  copiedIcon = <IconTick alignY="lowercase" />,
+  copiedLabel = 'Copied',
+  copyIcon = <IconCopy alignY="lowercase" />,
+  copyLabel = 'Copy',
   size,
 }: Props) => {
   const [copied, setCopied] = useState<boolean>(false);
@@ -47,12 +33,19 @@ export const CopyableText = ({
   }, [children, copied]);
 
   return copied ? (
-    <Text size={size} tone="positive" weight="medium">
+    <Text
+      icon={copiedIcon || undefined}
+      size={size}
+      tone="positive"
+      weight="medium"
+    >
       {copiedLabel}
     </Text>
   ) : (
     <Text size={size} weight="medium">
-      <TextLinkButton onClick={copyText}>{copyLabel}</TextLinkButton>
+      <TextLinkButton icon={copyIcon || undefined} onClick={copyText}>
+        {copyLabel}
+      </TextLinkButton>
     </Text>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5534,10 +5534,10 @@ braces@^3.0.2, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
-braid-design-system@31.20.0:
-  version "31.20.0"
-  resolved "https://registry.yarnpkg.com/braid-design-system/-/braid-design-system-31.20.0.tgz#22bcf839a228458c977f99d20217148e14fdcbe9"
-  integrity sha512-MoAoworj3BNRHUQ3KX+yYGIkqqt2Mr1mIEskhJV0zcPdvdjtLl5B8VQo2eiaTDL3xI4aan5PzTddPdSaolTLmQ==
+braid-design-system@31.21.0:
+  version "31.21.0"
+  resolved "https://registry.yarnpkg.com/braid-design-system/-/braid-design-system-31.21.0.tgz#6da21160fb8fc94fb78792a7e179ad87ea489b8e"
+  integrity sha512-jc7RAwqocZ4+D2Sy0QBGPPTZtdQYCCSOLlinXxknuTbyxfK6aeNx36I/CquhwuIaEnMEEU1s1VUzzTgGjAqYkQ==
   dependencies:
     "@capsizecss/core" "^3.0.0"
     "@capsizecss/vanilla-extract" "^1.0.0"


### PR DESCRIPTION
BREAKING CHANGE: Braid 31.21+ is now required.

`CopyableText` now has separate `copiedIcon` and `copyIcon` properties that occupy Braid's built-in text icon slots. You can hide the default icon when customising the label via `false`:

```diff
<CopyableText
+ copyIcon={false}
  copyLabel="Copy me"
/>
```