### PR TITLE
Load Braid themes explicitly in Storybook

### DIFF
--- a/src/storybook/controls.tsx
+++ b/src/storybook/controls.tsx
@@ -1,7 +1,7 @@
 import { DEFAULT_SIZE, SIZES, Size } from '../private/size';
 
 export interface BraidArgs {
-  braidThemeName: string;
+  braidThemeName: BraidThemeName;
 }
 
 export interface MdxArgs {
@@ -9,12 +9,12 @@ export interface MdxArgs {
 }
 
 export const defaultArgs = {
-  braidThemeName: 'apac',
+  braidThemeName: 'apac' as const,
   mdxSize: DEFAULT_SIZE,
   size: 'standard',
 };
 
-export type BraidThemeOptions = 'apac' | 'docs' | 'wireframe';
+export type BraidThemeName = 'apac' | 'docs' | 'wireframe';
 
 export const defaultArgTypes = {
   braidThemeName: {

--- a/src/storybook/decorators.tsx
+++ b/src/storybook/decorators.tsx
@@ -4,25 +4,24 @@
  * {@link https://github.com/storybookjs/storybook/issues/11984}
  */
 import { BraidProvider, Card, ContentBlock } from 'braid-design-system';
+import apac from 'braid-design-system/themes/apac';
+import docs from 'braid-design-system/themes/docs';
+import wireframe from 'braid-design-system/themes/wireframe';
 import React, { ReactNode } from 'react';
 import { Helmet, HelmetProvider } from 'react-helmet-async';
 import { BrowserRouter } from 'react-router-dom';
-import loadable from 'sku/@loadable/component';
 import { addDecorator } from 'sku/@storybook/react';
 
 import { MdxProvider, ScoobieLink } from '..';
 import { robotoHref, robotoMonoHref } from '../../typography';
 import { Size } from '../private/size';
 
-import { BraidThemeOptions } from './controls';
+import { BraidThemeName } from './controls';
 
-const BraidTheme = loadable.lib(
-  (props: { themeName: BraidThemeOptions }) =>
-    import(`braid-design-system/themes/${props.themeName}`),
-);
+const THEMES = { apac, docs, wireframe };
 
 interface ProviderProps {
-  braidThemeName: string;
+  braidThemeName: BraidThemeName;
   children: ReactNode;
 }
 
@@ -30,19 +29,11 @@ export const BraidStorybookProvider = ({
   braidThemeName,
   children,
 }: ProviderProps) => (
-  <BraidTheme themeName={braidThemeName}>
-    {({
-      default: theme,
-    }: {
-      default: React.ComponentProps<typeof BraidProvider>['theme'];
-    }) => (
-      <BraidProvider theme={theme} linkComponent={ScoobieLink}>
-        <ContentBlock>
-          <Card>{children}</Card>
-        </ContentBlock>
-      </BraidProvider>
-    )}
-  </BraidTheme>
+  <BraidProvider theme={THEMES[braidThemeName]} linkComponent={ScoobieLink}>
+    <ContentBlock>
+      <Card>{children}</Card>
+    </ContentBlock>
+  </BraidProvider>
 );
 
 interface MdxStorybookProviderProps {


### PR DESCRIPTION
The dynamic loadable approach we had before doesn't work with Braid 32. This gives us an opportunity to simplify our code as we don't need to microoptimise our Storybook.