### PR TITLE
fix(InlineCode): Use standard border radius

### DIFF
--- a/src/components/InlineCode.tsx
+++ b/src/components/InlineCode.tsx
@@ -16,7 +16,7 @@ export const InlineCode = ({ children, weight = 'regular' }: Props) => (
     {isHexColour(children) ? (
       <Box component="span" className={styles.colourBlockWrapper}>
         <Box
-          borderRadius="large"
+          borderRadius="standard"
           className={[
             styles.base,
             styles.colourBlock,
@@ -33,7 +33,7 @@ export const InlineCode = ({ children, weight = 'regular' }: Props) => (
     ) : undefined}
 
     <Box
-      borderRadius="large"
+      borderRadius="standard"
       className={[
         styles.base,
         styles.weight[weight],


### PR DESCRIPTION
This matches `Badge` and works better with the `seekJobs` theme.

https://github.com/seek-oss/braid-design-system/blob/e42c6f9168904f6b607c74157cafebf9b0147489/packages/braid-design-system/src/lib/components/Badge/Badge.tsx#L90