### PR TITLE
fix: Remove unresolvable `url` module import

### DIFF
--- a/src/components/CodeBlock/GraphQLPlaygroundAction.tsx
+++ b/src/components/CodeBlock/GraphQLPlaygroundAction.tsx
@@ -3,8 +3,6 @@ import React from 'react';
 
 import { SIZE_TO_SMALLER, type Size } from '../../private/size';
 
-const URL = window.URL;
-
 interface Props {
   query: string;
   variables: string | undefined;

--- a/src/components/CodeBlock/GraphQLPlaygroundAction.tsx
+++ b/src/components/CodeBlock/GraphQLPlaygroundAction.tsx
@@ -1,11 +1,9 @@
-import url from 'url';
-
 import { IconVideo, Text, TextLink } from 'braid-design-system';
 import React from 'react';
 
 import { SIZE_TO_SMALLER, type Size } from '../../private/size';
 
-const URL = url.URL ?? window.URL;
+const URL = window.URL;
 
 interface Props {
   query: string;

--- a/src/private/url.ts
+++ b/src/private/url.ts
@@ -1,6 +1,3 @@
-const URL = window.URL;
-const URLSearchParams = window.URLSearchParams;
-
 const EXAMPLE_BASE_URL = 'https://example.com';
 
 const parseVersionParams = (search: string) => {

--- a/src/private/url.ts
+++ b/src/private/url.ts
@@ -1,7 +1,5 @@
-import url from 'url';
-
-const URL = url.URL ?? window.URL;
-const URLSearchParams = url.URLSearchParams ?? window.URLSearchParams;
+const URL = window.URL;
+const URLSearchParams = window.URLSearchParams;
 
 const EXAMPLE_BASE_URL = 'https://example.com';
 


### PR DESCRIPTION
In Storybook 7, we can't resolve `url`. I'm assuming SB6 was polyfilling this.

`URL` and `URLSearchParam` are both available as globals in node and should be available in browsers - https://nodejs.org/api/globals.html