### PR TITLE
fix(CodeBlock): Fix JSON syntax highlighting

### DIFF
--- a/src/private/Prism.ts
+++ b/src/private/Prism.ts
@@ -4,11 +4,14 @@ import csharpLang from 'refractor/lang/csharp';
 // @ts-ignore
 import httpLang from 'refractor/lang/http';
 // @ts-ignore
+import jsonLang from 'refractor/lang/json';
+// @ts-ignore
 import splunkSplLang from 'refractor/lang/splunk-spl';
 
 csharpLang(Prism);
 httpLang(Prism);
 splunkSplLang(Prism);
+jsonLang(Prism);
 
 export { Prism } from 'prism-react-renderer';
 export { themes } from 'prism-react-renderer';


### PR DESCRIPTION
JSON syntax highlighting is broken, likely since merging this PR in https://github.com/seek-oss/scoobie/pull/509 which upgraded `prism-react-renderer` from 1.3.5 to 2.0.4. This newer version does not have JSON as a bundled language -> https://github.com/FormidableLabs/prism-react-renderer/blob/master/packages/generate-prism-languages/index.ts#L9-L23, hence we need to pull it in ourselves 