### PR TITLE
fix(CodeBlock): Support `diff` highlighting

### DIFF
--- a/src/private/Prism.ts
+++ b/src/private/Prism.ts
@@ -2,6 +2,8 @@ import { Prism } from 'prism-react-renderer';
 // @ts-ignore
 import csharpLang from 'refractor/lang/csharp';
 // @ts-ignore
+import diffLang from 'refractor/lang/diff';
+// @ts-ignore
 import httpLang from 'refractor/lang/http';
 // @ts-ignore
 import jsonLang from 'refractor/lang/json';
@@ -9,6 +11,7 @@ import jsonLang from 'refractor/lang/json';
 import splunkSplLang from 'refractor/lang/splunk-spl';
 
 csharpLang(Prism);
+diffLang(Prism);
 httpLang(Prism);
 splunkSplLang(Prism);
 jsonLang(Prism);

--- a/src/storybook/markdown/code.mdx
+++ b/src/storybook/markdown/code.mdx
@@ -112,7 +112,7 @@ JSON:
 GraphQL:
 
 ```graphql
-query($id: String!) {
+query ($id: String!) {
   candidate(id: $id) {
     id {
       value
@@ -245,3 +245,10 @@ Width and height:
 - ```go
    fmt.Println("this line is loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong")
   ```
+
+---
+
+```diff
+- removed
++ added
+```


### PR DESCRIPTION
We've been using `diff` code blocks but they lack syntax highlighting:

https://developer.seek.com/migration-guides/jobstreet-and-jobsdb-uplift/phase-2-job-posting/ad-selection#option-1-ad-selection-panel