### PR TITLE
feat: Make @mdx-js/loader an optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "version": "0.0.0-semantically-released",
   "dependencies": {
     "@capsizecss/core": "^3.0.0",
-    "@mdx-js/loader": "^1.6.22",
     "@mdx-js/react": "^1.6.22",
     "@types/mdx-js__react": "^1.5.5",
     "@vanilla-extract/css": "^1.2.3",
@@ -42,7 +41,8 @@
     "react-router-dom": "6.16.0",
     "semantic-release": "21.1.2",
     "sku": "12.4.2",
-    "webpack": "5.88.2"
+    "webpack": "5.88.2",
+    "@mdx-js/loader": "^1.6.22"
   },
   "files": [
     "src",
@@ -57,10 +57,14 @@
     "braid-design-system": ">= 31.21.0",
     "react": ">= 17 < 19",
     "react-router-dom": ">= 5.3.0",
-    "sku": ">= 10.13.4 < 13"
+    "sku": ">= 10.13.4 < 13",
+    "@mdx-js/loader": "^1.6.22"
   },
   "peerDependenciesMeta": {
     "@mermaid-js/mermaid-cli": {
+      "optional": true
+    },
+    "@mdx-js/loader": {
       "optional": true
     }
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4658,9 +4658,8 @@
     "@types/emscripten" "^1.39.6"
     tslib "^1.13.0"
 
-"@zendesk/babel-plugin-react-displayname@github:zendesk/babel-plugin-react-displayname#7a837f2":
+"@zendesk/babel-plugin-react-displayname@zendesk/babel-plugin-react-displayname#7a837f2":
   version "1.0.0"
-  uid "7a837f2e92fbd6c5e348dcd178dc9de05309a804"
   resolved "https://codeload.github.com/zendesk/babel-plugin-react-displayname/tar.gz/7a837f2e92fbd6c5e348dcd178dc9de05309a804"
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
@@ -14113,7 +14112,7 @@ sku@12.4.2:
     "@vocab/phrase" "^1.2.4"
     "@vocab/pseudo-localize" "^1.0.1"
     "@vocab/webpack" "^1.2.1"
-    "@zendesk/babel-plugin-react-displayname" "github:zendesk/babel-plugin-react-displayname#7a837f2"
+    "@zendesk/babel-plugin-react-displayname" zendesk/babel-plugin-react-displayname#7a837f2
     autoprefixer "^10.3.1"
     babel-jest "^29.0.0"
     babel-loader "^9.1.2"


### PR DESCRIPTION
BREAKING CHANGE: If importing `scoobie/webpack`, you'll need to add this optional peer dependency:

```sh
yarn add '@mdx-js/loader@^1.6.22'
```

This is to avoid including dependencies which have some security vulnerabilities (CVE-2020-7753, CVE-2022-37601, CVE-2022-37599, CVE-2022-37603) if unnecessary. This is a bridge until https://github.com/seek-oss/scoobie/issues/566