### PR TITLE
Suppress sku telemetry warnings in CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,6 +12,8 @@ jobs:
     permissions:
       checks: write
     runs-on: ubuntu-latest
+    env:
+      SKU_TELEMETRY: false
     steps:
       - name: Check out repo
         uses: actions/checkout@v4


### PR DESCRIPTION
We don't have `@seek` deps on this OSS project.

https://github.com/seek-oss/scoobie/actions/runs/6952083290/job/18915097308#step:5:10