### PR TITLE
feat(Table): Add `overflowX` and `whiteSpace` props

### DIFF
--- a/.changeset/forty-melons-rhyme.md
+++ b/.changeset/forty-melons-rhyme.md
@@ -1,0 +1,17 @@
+---
+'scoobie': minor
+---
+
+Table: Add `overflowX` and `whiteSpace` props
+
+These allow you to control overflow and wrapping behaviour when width is constrained.
+
+```tsx
+<>
+  <Table />
+
+  <Table overflowX="scroll" />
+
+  <Table overflowX="scroll" whiteSpace="nowrap" />
+</>
+```

--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -79,7 +79,7 @@ export const CodeBlock = ({
 
   return (
     <Stack space={tablePadding}>
-      <ScrollableInline>
+      <ScrollableInline whiteSpace="nowrap">
         <Box display="flex" justifyContent="spaceBetween">
           <Box display="flex">
             {children.map(({ label }, labelIndex) => (

--- a/src/components/Table.stories.tsx
+++ b/src/components/Table.stories.tsx
@@ -11,12 +11,19 @@ export default {
   component: Component,
   args: {
     size: 'standard',
-    width: undefined,
   },
   argTypes: {
+    overflowX: {
+      control: { type: 'radio' },
+      options: [undefined, 'scroll'],
+    },
     size: {
       control: { type: 'radio' },
       options: ['standard', 'large'],
+    },
+    whiteSpace: {
+      control: { type: 'radio' },
+      options: [undefined, 'nowrap'],
     },
     width: {
       control: { type: 'radio' },

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -12,7 +12,7 @@ import { DEFAULT_SIZE, type Size } from '../private/size';
 
 import { TableRow } from './TableRow';
 
-interface Props {
+interface BaseProps {
   align?: readonly TableAlign[];
   children: ReactNode;
   header: ComponentProps<typeof Stack>['children'] | readonly string[];
@@ -21,15 +21,29 @@ interface Props {
   width?: 'full';
 }
 
+type Props = BaseProps &
+  (
+    | {
+        overflowX: 'scroll';
+        whiteSpace?: 'nowrap';
+      }
+    | {
+        overflowX?: never;
+        whiteSpace?: never;
+      }
+  );
+
 export const Table = ({
   align,
   children,
   header,
+  overflowX,
   size = DEFAULT_SIZE,
   type = DEFAULT_TABLE_TYPE,
+  whiteSpace,
   width,
 }: Props) => (
-  <BaseTable width={width}>
+  <BaseTable overflowX={overflowX} whiteSpace={whiteSpace} width={width}>
     <TableContext.Provider
       value={{
         align,

--- a/src/private/ScrollableInline.css.ts
+++ b/src/private/ScrollableInline.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@vanilla-extract/css';
+import { style, styleVariants } from '@vanilla-extract/css';
 import { calc } from '@vanilla-extract/css-utils';
 import { vars } from 'braid-design-system/css';
 
@@ -12,7 +12,11 @@ export const scrollX = style({
   overflowX: 'auto',
   overflowY: 'hidden',
   scrollbarWidth: 'none',
-  whiteSpace: 'nowrap',
 
   WebkitOverflowScrolling: 'touch',
 });
+
+export const whiteSpace = styleVariants(
+  { undefined, nowrap: 'nowrap' } as const,
+  (value) => ({ whiteSpace: value }),
+);

--- a/src/private/ScrollableInline.tsx
+++ b/src/private/ScrollableInline.tsx
@@ -1,16 +1,21 @@
-import { Box } from 'braid-design-system';
+import { Bleed, Box } from 'braid-design-system';
 import React, { type ReactNode } from 'react';
 
 import * as styles from './ScrollableInline.css';
 
 interface Props {
   children: ReactNode;
+  whiteSpace?: 'nowrap';
 }
 
-export const ScrollableInline = ({ children }: Props) => (
-  <Box className={styles.trimPaddingY}>
-    <Box className={styles.scrollX} paddingY="small" width="full">
+export const ScrollableInline = ({ children, whiteSpace }: Props) => (
+  <Bleed vertical="small">
+    <Box
+      className={[styles.scrollX, styles.whiteSpace[whiteSpace ?? 'undefined']]}
+      paddingY="small"
+      width="full"
+    >
       {children}
     </Box>
-  </Box>
+  </Bleed>
 );

--- a/src/private/Table.tsx
+++ b/src/private/Table.tsx
@@ -1,6 +1,7 @@
 import { Box } from 'braid-design-system';
-import React, { type ReactNode } from 'react';
+import React, { Fragment, type ReactNode } from 'react';
 
+import { ScrollableInline } from './ScrollableInline';
 import {
   DEFAULT_TABLE_CELL_COMPONENT,
   DEFAULT_TABLE_TYPE,
@@ -13,17 +14,33 @@ import * as styles from './Table.css';
 
 interface BaseTableProps {
   children: ReactNode;
+  overflowX?: 'scroll';
+  whiteSpace?: 'nowrap';
   width?: 'full';
 }
 
-export const BaseTable = ({ children, width }: BaseTableProps) => (
-  <Box
-    component="table"
-    className={{ [styles.table]: true, [styles.fullWidth]: width === 'full' }}
-  >
-    {children}
-  </Box>
-);
+export const BaseTable = ({
+  children,
+  overflowX,
+  whiteSpace,
+  width,
+}: BaseTableProps) => {
+  const Wrapper = overflowX === 'scroll' ? ScrollableInline : Fragment;
+
+  return (
+    <Wrapper {...(overflowX === 'scroll' ? { whiteSpace } : {})}>
+      <Box
+        component="table"
+        className={{
+          [styles.table]: true,
+          [styles.fullWidth]: width === 'full',
+        }}
+      >
+        {children}
+      </Box>
+    </Wrapper>
+  );
+};
 
 interface MdxTableProps {
   children: ReactNode;


### PR DESCRIPTION
| Default | `overflowX="scroll"` | `overflowX="scroll" whiteSpace="nowrap"`
| :-: | :-: | :-:
| ![Screen Shot 2024-01-23 at 08 28 04](https://github.com/seek-oss/scoobie/assets/25572311/cd299385-51a4-4835-95e8-c3ea99c6928a) | ![Screen Shot 2024-01-23 at 08 28 12](https://github.com/seek-oss/scoobie/assets/25572311/f5289874-855d-4493-98fa-43c449eef1d1) | ![Screen Shot 2024-01-23 at 08 28 16](https://github.com/seek-oss/scoobie/assets/25572311/02171a66-d1da-4f61-a413-02913620b3ac)

---

Motivation: https://developer.seek.com/schema can look a bit shoddy on mobile:

![Screen Shot 2024-01-23 at 08 30 25](https://github.com/seek-oss/scoobie/assets/25572311/f2e70601-e9a3-44b7-839e-1e6567a14611)
