### PR TITLE
mermaid: Outline edge labels

### DIFF
--- a/.changeset/old-tomatoes-hide.md
+++ b/.changeset/old-tomatoes-hide.md
@@ -1,0 +1,5 @@
+---
+'scoobie': patch
+---
+
+mermaid: Outline edge labels instead of drawing a translucent background box

--- a/remark/mermaid/style.css
+++ b/remark/mermaid/style.css
@@ -6,9 +6,6 @@
     Arial, sans-serif;
   --mermaid-font-size: 14px;
 
-  /* https://github.com/mermaid-js/mermaid/blob/8.11.5/src/diagrams/er/erRenderer.js#L405-L406 */
-  --mermaid-er-label-fill: rgba(255, 255, 255, 0.85);
-
   /* https://github.com/seek-oss/braid-design-system/blob/v31.14.0/lib/color/palette.ts */
   --braid-blue-100: #e3f2fb;
   --braid-blue-300: #98c9f1;
@@ -42,7 +39,7 @@ path.er.entityBox {
 }
 
 path.er.relationshipLabelBox {
-  fill: var(--mermaid-er-label-fill);
+  fill: none;
 }
 
 path.er.relationshipLine {
@@ -53,6 +50,13 @@ path.er.relationshipLine {
 text.er {
   dominant-baseline: central;
   text-anchor: middle;
+}
+
+text.er.relationshipLabel {
+  paint-order: stroke fill;
+  stroke: #fff;
+  stroke-linejoin: round;
+  stroke-width: 4px;
 }
 
 /* flowchart v2 */
@@ -87,12 +91,11 @@ g.label foreignObject {
   overflow-x: visible;
 }
 
-.edgeLabel div {
-  background-color: var(--mermaid-er-label-fill);
-}
-
 .edgeLabel span.edgeLabel {
   background-color: transparent;
+
+  -webkit-text-stroke-color: #fff;
+  -webkit-text-stroke-width: 4px;
 }
 
 circle.label-container,


### PR DESCRIPTION
The previous approach wasn't:

- Particularly nice to look at
- Correctly spanning the width of the label
- Going to work well with dark mode

| Mode | Before | After
| :-: | :-: | :-:
| Light | ![Screen Shot 2024-09-04 at 10 26 47](https://github.com/user-attachments/assets/f7431568-6d60-439a-9260-b242f4e3e00a) | ![Screen Shot 2024-09-04 at 10 26 54](https://github.com/user-attachments/assets/b440c467-4a75-4e5b-ab51-0404a5f7b87b)
| Dark | ![Screen Shot 2024-09-04 at 10 27 05](https://github.com/user-attachments/assets/db7cc3fd-6285-4f78-908d-f814eb51791e) | ![Screen Shot 2024-09-04 at 10 27 09](https://github.com/user-attachments/assets/1548176e-9bf8-47ab-a700-e2a01899749c)
