### PR TITLE
mermaid: Fix Chrome regression with label overflow hack

### DIFF
--- a/.changeset/late-plums-flow.md
+++ b/.changeset/late-plums-flow.md
@@ -1,0 +1,7 @@
+---
+'scoobie': patch
+---
+
+mermaid: Restore flowchart labels in Chrome
+
+This fixes regression in [v17.1.2](https://github.com/seek-oss/scoobie/releases/tag/v17.1.2) where cut-off labels had a scrollbar rendered over them in Chrome.

--- a/remark/mermaid/style.css
+++ b/remark/mermaid/style.css
@@ -89,6 +89,7 @@ g.node foreignObject.label {
 g.edgeLabel foreignObject,
 g.label foreignObject {
   overflow-x: visible;
+  scrollbar-width: none;
 }
 
 .edgeLabel span.edgeLabel {


### PR DESCRIPTION
These were just showing as scrollbars 🙂‍↔️