### PR TITLE
mermaid: Fix flowchart labels being cut off in Chrome

### DIFF
--- a/.changeset/poor-doors-explain.md
+++ b/.changeset/poor-doors-explain.md
@@ -1,0 +1,5 @@
+---
+'scoobie': patch
+---
+
+mermaid: Fix flowchart labels being cut off in Chrome

--- a/remark/mermaid/style.css
+++ b/remark/mermaid/style.css
@@ -82,14 +82,10 @@ g.node span.nodeLabel {
   font-size: var(--mermaid-font-size);
 }
 
-g.node foreignObject.label {
-  overflow-y: visible;
-}
-
 g.edgeLabel foreignObject,
-g.label foreignObject {
-  overflow-x: visible;
-  scrollbar-width: none;
+g.label foreignObject,
+g.node foreignObject.label {
+  overflow: visible;
 }
 
 .edgeLabel span.edgeLabel {


### PR DESCRIPTION
I decided to actually RTFM. I think Blink is doing the specful thing here and this should be the proper fix for #698 / #707.

https://developer.mozilla.org/en-US/docs/Web/CSS/overflow#description

> Setting `overflow` to visible in one direction (i.e. `overflow-x` or
> `overflow-y`) when it isn't set to `visible` or `clip` in the other
> direction results in the `visible` value behaving as `auto`.