### PR TITLE
mermaid: Handle optional `tspan`s in sequence diagrams

### DIFF
--- a/.changeset/fluffy-dryers-chew.md
+++ b/.changeset/fluffy-dryers-chew.md
@@ -1,0 +1,5 @@
+---
+'scoobie': patch
+---
+
+mermaid: Handle optional `tspan`s in sequence diagrams

--- a/remark/mermaid/style.css
+++ b/remark/mermaid/style.css
@@ -293,6 +293,7 @@ text.messageText {
 }
 
 text.loopText,
+text.loopText > tspan,
 text.messageText {
   paint-order: stroke fill;
   stroke: var(--surface-background);
@@ -300,10 +301,13 @@ text.messageText {
   stroke-width: 4px;
 }
 
+text.actor,
 text.actor > tspan,
 text.labelText,
+text.loopText,
 text.loopText > tspan,
 text.messageText,
+text.noteText,
 text.noteText > tspan {
   fill: var(--neutral-foreground);
 }


### PR DESCRIPTION
I haven't bothered to dig into why these elements are added sometimes and omitted other times.